### PR TITLE
fix: stabilize deterministic archive entry ordering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -254,7 +254,9 @@ class DirArchiver {
 			// Create a file to stream archive data to.
 			output = fs.createWriteStream( this.zipPath );
 			archive = archiver( 'zip', {
-				zlib: { level: 9 }
+				zlib: { level: 9 },
+				// Keep deterministic entry ordering across platforms.
+				statConcurrency: 1
 			} );
 
 			// Catch warnings during archiving.


### PR DESCRIPTION
Fixes flaky Windows CI failure on  () by forcing deterministic archiver stat scheduling ().\n\nVerification:\n- npm run lint\n- npm test