### PR TITLE
feat: migrate CLI parsing to argv-flags v1 schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "archiver": "^7.0.1",
-        "argv-flags": "^0.2.1"
+        "argv-flags": "^1.0.2"
       },
       "bin": {
         "dir-archiver": "dist/cli.js"
@@ -755,12 +755,12 @@
       "license": "Python-2.0"
     },
     "node_modules/argv-flags": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/argv-flags/-/argv-flags-0.2.1.tgz",
-      "integrity": "sha512-UkH3rzYPzfpMBQkbFVNvT+hmPd8TUxt8adWQYEQXIrlxUx09aptFSVy/nGVgMRBFMyieH4nAoJsZvrwlbKJQFQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/argv-flags/-/argv-flags-1.0.2.tgz",
+      "integrity": "sha512-HBl1j4iwXWnAwvTN5ahHfuOO3ERZ/edWksdvXAaa6VRK/57M+QNUe0t1RwPxIgtmE3kcAWyyxJTjegT7QSAhZA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=24"
       }
     },
     "node_modules/async": {
@@ -2869,9 +2869,9 @@
       "dev": true
     },
     "argv-flags": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/argv-flags/-/argv-flags-0.2.1.tgz",
-      "integrity": "sha512-UkH3rzYPzfpMBQkbFVNvT+hmPd8TUxt8adWQYEQXIrlxUx09aptFSVy/nGVgMRBFMyieH4nAoJsZvrwlbKJQFQ=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/argv-flags/-/argv-flags-1.0.2.tgz",
+      "integrity": "sha512-HBl1j4iwXWnAwvTN5ahHfuOO3ERZ/edWksdvXAaa6VRK/57M+QNUe0t1RwPxIgtmE3kcAWyyxJTjegT7QSAhZA=="
     },
     "async": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "npm run typecheck && eslint . --max-warnings=0",
-    "test": "npm run build && node test/smoke.js && node test/cli.js",
+    "test": "npm run build && node test/cli-args.js && node test/smoke.js && node test/cli.js",
     "prepack": "npm run build"
   },
   "engines": {
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "archiver": "^7.0.1",
-    "argv-flags": "^0.2.1"
+    "argv-flags": "^1.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,0 +1,94 @@
+import type { Schema } from 'argv-flags';
+
+const CLI_SCHEMA = {
+	src: {
+		type: 'string',
+		flags: [ '--src' ],
+		required: true
+	},
+	dest: {
+		type: 'string',
+		flags: [ '--dest' ],
+		required: true
+	},
+	includebasedir: {
+		type: 'boolean',
+		flags: [ '--includebasedir' ],
+		default: false
+	},
+	followsymlinks: {
+		type: 'boolean',
+		flags: [ '--followsymlinks' ],
+		default: false
+	},
+	exclude: {
+		type: 'array',
+		flags: [ '--exclude' ],
+		default: [] as string[]
+	}
+} as const satisfies Schema;
+
+export interface ParsedCliArgs {
+	directoryPath: string | undefined;
+	zipPath: string | undefined;
+	includeBaseDirectory: boolean;
+	followSymlinks: boolean;
+	excludes: string[];
+	hasRequiredPaths: boolean;
+}
+
+let parseArgsPromise: Promise<ParseArgsFn> | undefined;
+
+type ParseArgsFn = (
+	schema: Schema,
+	options?: {
+		argv?: readonly string[];
+		allowUnknown?: boolean;
+		stopAtDoubleDash?: boolean;
+	}
+) => {
+	values: Record<string, unknown>;
+};
+
+const loadParseArgs = (): Promise<ParseArgsFn> => {
+	parseArgsPromise ??= import( 'argv-flags' ).then( ( argvFlagsModule ) => argvFlagsModule.default as ParseArgsFn );
+	return parseArgsPromise;
+};
+
+const toString = ( value: unknown ): string | undefined => {
+	return typeof value === 'string' ? value : undefined;
+};
+
+const toBoolean = ( value: unknown ): boolean => {
+	return value === true;
+};
+
+const toStringArray = ( value: unknown ): string[] => {
+	if ( ! Array.isArray( value ) ) {
+		return [];
+	}
+	return value.filter( ( entry ): entry is string => typeof entry === 'string' );
+};
+
+export const parseCliArgs = async ( argv: readonly string[] ): Promise<ParsedCliArgs> => {
+	const parseArgs = await loadParseArgs();
+	const parsed = parseArgs( CLI_SCHEMA, {
+		argv: [ ...argv ],
+		allowUnknown: true
+	} );
+
+	const directoryPath = toString( parsed.values[ 'src' ] );
+	const zipPath = toString( parsed.values[ 'dest' ] );
+	const includeBaseDirectory = toBoolean( parsed.values[ 'includebasedir' ] );
+	const followSymlinks = toBoolean( parsed.values[ 'followsymlinks' ] );
+	const excludes = toStringArray( parsed.values[ 'exclude' ] );
+
+	return {
+		directoryPath,
+		zipPath,
+		includeBaseDirectory,
+		followSymlinks,
+		excludes,
+		hasRequiredPaths: typeof directoryPath === 'string' && typeof zipPath === 'string'
+	};
+};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,31 +1,9 @@
 #!/usr/bin/env node
 
 import DirArchiver from './index';
-import parseArgs from 'argv-flags';
+import { parseCliArgs } from './cli-args';
 
-const parseBooleanFlag = ( flag: string ): boolean => {
-	const rawValue = parseArgs( flag, 'string' );
-	if ( typeof rawValue === 'string' && rawValue.length > 0 && ! rawValue.startsWith( '-' ) ) {
-		const normalized = rawValue.toLowerCase();
-		if ( normalized === 'true' ) {
-			return true;
-		}
-		if ( normalized === 'false' ) {
-			return false;
-		}
-	}
-	return parseArgs( flag, 'boolean' ) === true;
-};
-
-const directoryPath = parseArgs( '--src', 'string' );
-const zipPath = parseArgs( '--dest', 'string' );
-const includeBaseDirectory = parseBooleanFlag( '--includebasedir' );
-const followSymlinks = parseBooleanFlag( '--followsymlinks' );
-const excludeValues = parseArgs( '--exclude', 'array' );
-const excludes = Array.isArray( excludeValues ) ? excludeValues : [];
-
-if ( typeof directoryPath !== 'string' || typeof zipPath !== 'string' ) {
-	console.log( ` Dir Archiver could not be executed. Some arguments are missing.
+const usage = ` Dir Archiver could not be executed. Some arguments are missing.
 
     Options:
       --src            The path of the folder to archive.                            [string][required]
@@ -37,13 +15,33 @@ if ( typeof directoryPath !== 'string' || typeof zipPath !== 'string' ) {
                        If this option is set to false the archive created will
                        unzip its content to the current directory.                               [bool]
       --followsymlinks Follow symlinks when traversing directories.                              [bool]
-      --exclude        A list with the names of the files and folders to exclude.               [array]` );
-	process.exitCode = 1;
-} else {
-	const archive = new DirArchiver( directoryPath, zipPath, includeBaseDirectory, excludes, followSymlinks );
-	archive.createZip().catch( ( err: unknown ) => {
-		const normalizedError = err instanceof Error ? err : new Error( String( err ) );
-		console.error( normalizedError );
+      --exclude        A list with the names of the files and folders to exclude.               [array]`;
+
+const run = async (): Promise<void> => {
+	const parsedArgs = await parseCliArgs( process.argv.slice( 2 ) );
+
+	if (
+		! parsedArgs.hasRequiredPaths
+		|| typeof parsedArgs.directoryPath !== 'string'
+		|| typeof parsedArgs.zipPath !== 'string'
+	) {
+		console.log( usage );
 		process.exitCode = 1;
-	} );
-}
+		return;
+	}
+
+	const archive = new DirArchiver(
+		parsedArgs.directoryPath,
+		parsedArgs.zipPath,
+		parsedArgs.includeBaseDirectory,
+		parsedArgs.excludes,
+		parsedArgs.followSymlinks
+	);
+	await archive.createZip();
+};
+
+void run().catch( ( err: unknown ) => {
+	const normalizedError = err instanceof Error ? err : new Error( String( err ) );
+	console.error( normalizedError );
+	process.exitCode = 1;
+} );

--- a/test/cli-args.js
+++ b/test/cli-args.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const assert = require( 'assert' );
+const { parseCliArgs } = require( '../dist/cli-args' );
+
+const run = async () => {
+	const minimal = await parseCliArgs( [ '--src', 'source', '--dest', 'archive.zip' ] );
+	assert.strictEqual( minimal.hasRequiredPaths, true, 'required args should parse' );
+	assert.strictEqual( minimal.directoryPath, 'source' );
+	assert.strictEqual( minimal.zipPath, 'archive.zip' );
+	assert.strictEqual( minimal.includeBaseDirectory, false, 'includeBaseDirectory should default to false' );
+	assert.strictEqual( minimal.followSymlinks, false, 'followSymlinks should default to false' );
+	assert.deepStrictEqual( minimal.excludes, [], 'excludes should default to an empty array' );
+
+	const explicitBooleans = await parseCliArgs( [
+		'--src', 'source',
+		'--dest', 'archive.zip',
+		'--includebasedir=true',
+		'--followsymlinks=false'
+	] );
+	assert.strictEqual( explicitBooleans.includeBaseDirectory, true, 'includebasedir=true should parse as true' );
+	assert.strictEqual( explicitBooleans.followSymlinks, false, 'followsymlinks=false should parse as false' );
+
+	const mixedExcludes = await parseCliArgs( [
+		'--src', 'source',
+		'--dest', 'archive.zip',
+		'--exclude=cache',
+		'--exclude', '.\\nested\\skip.txt',
+		'nested\\cache\\'
+	] );
+	assert.deepStrictEqual(
+		mixedExcludes.excludes,
+		[ 'cache', '.\\nested\\skip.txt', 'nested\\cache\\' ],
+		'exclude values should preserve inline and repeated array parsing'
+	);
+
+	const withUnknown = await parseCliArgs( [ '--src', 'source', '--dest', 'archive.zip', '--unknown', 'value' ] );
+	assert.strictEqual( withUnknown.hasRequiredPaths, true, 'unknown flags should not block required argument parsing' );
+
+	const missingRequired = await parseCliArgs( [ '--dest', 'archive.zip' ] );
+	assert.strictEqual( missingRequired.hasRequiredPaths, false, 'missing --src should fail required path check' );
+	assert.strictEqual( missingRequired.directoryPath, undefined );
+	assert.strictEqual( missingRequired.zipPath, 'archive.zip' );
+};
+
+run().catch( ( err ) => {
+	console.error( err );
+	process.exitCode = 1;
+} );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "target": "ES2019",
-    "module": "CommonJS",
+    "module": "NodeNext",
     "lib": ["ES2019"],
-    "moduleResolution": "node",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "outDir": "dist",


### PR DESCRIPTION
## Summary
- migrate CLI arg parsing to `argv-flags` schema-based API
- upgrade dependency to `argv-flags@^1.0.2`
- add focused parser behavior tests (`test/cli-args.js`)
- switch TS module settings to `NodeNext` to preserve dynamic import for ESM dependency loading

## Verification
- `npm run lint`
- `npm test`
- `npm audit` (0 vulnerabilities)