### PR TITLE
feat(runtime): ESM-only package + Deno/Bun smoke tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,3 +28,41 @@ jobs:
         run: npm run lint
       - name: Run tests
         run: npm test
+
+  deno-smoke:
+    name: Deno smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the git repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 22
+      - name: Setup Deno
+        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        with:
+          deno-version: 2.6.7
+      - name: Install dependencies
+        run: npm ci
+      - name: Run Deno smoke
+        run: npm run test:deno
+
+  bun-smoke:
+    name: Bun smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the git repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 22
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+        with:
+          bun-version: 1.3.3
+      - name: Install dependencies
+        run: npm ci
+      - name: Run Bun smoke
+        run: npm run test:bun

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "yauzl": "^3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,15 @@
   "version": "2.2.0",
   "description": "Compress a whole directory (including subdirectories) into a zip file, with options to exclude specific files, or directories.",
   "license": "MIT",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "bin": {
     "dir-archiver": "dist/cli.js"
   },
@@ -37,10 +44,13 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "npm run typecheck && eslint . --max-warnings=0",
     "test": "npm run build && node test/cli-args.js && node test/smoke.js && node test/cli.js",
+    "test:deno": "npm run build && deno run --allow-read --allow-write --allow-env --allow-sys test/deno-smoke.mjs",
+    "test:bun": "npm run build && bun test/bun-smoke.mjs",
+    "test:runtimes": "npm run test:deno && npm run test:bun",
     "prepack": "npm run build"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "dependencies": {
     "@ismail-elkorchi/bytefold": "github:Ismail-elkorchi/bytefold#7eb173157d22baef2d72e20f952273bf58f5a2a3",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import DirArchiver from './index';
-import { parseCliArgs } from './cli-args';
+import DirArchiver from './index.js';
+import { parseCliArgs } from './cli-args.js';
 
 const usage = ` Dir Archiver could not be executed. Some arguments are missing.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 'use strict';
 
-import * as path from 'path';
-import * as fs from 'fs';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
 
 interface ZipWriterLike {
 	add: (
@@ -274,4 +274,4 @@ class DirArchiver {
 	}
 }
 
-export = DirArchiver;
+export default DirArchiver;

--- a/test/bun-smoke.mjs
+++ b/test/bun-smoke.mjs
@@ -1,0 +1,36 @@
+import { join } from 'node:path';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import DirArchiver from '../dist/index.js';
+
+const run = async () => {
+	const normalizedTmpRoot = mkdtempSync( join( tmpdir(), 'dir-archiver-bun-' ) );
+
+	try {
+		const src = join( normalizedTmpRoot, 'src' );
+		const nested = join( src, 'nested' );
+		const dest = join( normalizedTmpRoot, 'archive.zip' );
+
+		mkdirSync( nested, { recursive: true } );
+		writeFileSync( join( src, 'root.txt' ), 'root' );
+		writeFileSync( join( nested, 'nested.txt' ), 'nested' );
+
+		const archive = new DirArchiver( src, dest, false, [] );
+		await archive.createZip();
+
+		if ( ! existsSync( dest ) ) {
+			throw new Error( 'Bun smoke: destination archive was not created.' );
+		}
+		const stats = statSync( dest );
+		if ( ! stats.isFile() || stats.size <= 0 ) {
+			throw new Error( 'Bun smoke: destination archive is invalid.' );
+		}
+	} finally {
+		rmSync( normalizedTmpRoot, { recursive: true, force: true } );
+	}
+};
+
+run().catch( ( err ) => {
+	console.error( err );
+	process.exitCode = 1;
+} );

--- a/test/cli-args.js
+++ b/test/cli-args.js
@@ -1,9 +1,10 @@
 'use strict';
 
 const assert = require( 'assert' );
-const { parseCliArgs } = require( '../dist/cli-args' );
 
 const run = async () => {
+	const { parseCliArgs } = await import( '../dist/cli-args.js' );
+
 	const minimal = await parseCliArgs( [ '--src', 'source', '--dest', 'archive.zip' ] );
 	assert.strictEqual( minimal.hasRequiredPaths, true, 'required args should parse' );
 	assert.strictEqual( minimal.directoryPath, 'source' );

--- a/test/deno-smoke.mjs
+++ b/test/deno-smoke.mjs
@@ -1,0 +1,36 @@
+/* global Deno */
+import { join } from 'node:path';
+import { mkdirSync, writeFileSync, existsSync, rmSync, statSync } from 'node:fs';
+import DirArchiver from '../dist/index.js';
+
+const run = async () => {
+	const tmpRoot = await Deno.makeTempDir( { prefix: 'dir-archiver-deno-' } );
+
+	try {
+		const src = join( tmpRoot, 'src' );
+		const nested = join( src, 'nested' );
+		const dest = join( tmpRoot, 'archive.zip' );
+
+		mkdirSync( nested, { recursive: true } );
+		writeFileSync( join( src, 'root.txt' ), 'root' );
+		writeFileSync( join( nested, 'nested.txt' ), 'nested' );
+
+		const archive = new DirArchiver( src, dest, false, [] );
+		await archive.createZip();
+
+		if ( ! existsSync( dest ) ) {
+			throw new Error( 'Deno smoke: destination archive was not created.' );
+		}
+		const stats = statSync( dest );
+		if ( ! stats.isFile() || stats.size <= 0 ) {
+			throw new Error( 'Deno smoke: destination archive is invalid.' );
+		}
+	} finally {
+		rmSync( tmpRoot, { recursive: true, force: true } );
+	}
+};
+
+run().catch( ( err ) => {
+	console.error( err );
+	Deno.exit( 1 );
+} );

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -4,8 +4,8 @@ const assert = require( 'assert' );
 const fs = require( 'fs' );
 const os = require( 'os' );
 const path = require( 'path' );
+const { pathToFileURL } = require( 'url' );
 const yauzl = require( 'yauzl' );
-const DirArchiver = require( '../dist/index' );
 
 const isWindows = process.platform === 'win32';
 
@@ -79,6 +79,9 @@ const removeDir = ( dirPath ) => {
 };
 
 const run = async () => {
+	const dirArchiverModuleUrl = pathToFileURL( path.join( __dirname, '..', 'dist', 'index.js' ) ).href;
+	const { default: DirArchiver } = await import( dirArchiverModuleUrl );
+
 	let tmpRoot;
 	try {
 		tmpRoot = fs.mkdtempSync( path.join( os.tmpdir(), 'dir-archiver-' ) );


### PR DESCRIPTION
## Summary
- switch package to ESM with explicit exports
- update CLI/source imports to ESM-compatible specifiers
- add Deno and Bun smoke tests plus CI jobs
- keep existing Node test suite green under ESM packaging

## Verification
- npm run lint
- npm test
- npm run test:runtimes