### PR TITLE
feat(release): automate npm+JSR publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  npm:
+    name: Publish npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          always-auth: true
+          cache: npm
+      - name: Setup Deno
+        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        with:
+          deno-version: 2.6.7
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+        with:
+          bun-version: 1.3.3
+      - name: Install
+        run: npm ci
+      - name: Quality gates
+        run: npm run lint && npm test && npm run test:runtimes
+      - name: Fail on tracked-file churn
+        shell: bash
+        run: |
+          if [[ -n "$(git status --porcelain=v1)" ]]; then
+            echo "Tracked files changed during CI run:"
+            git status --porcelain=v1
+            exit 1
+          fi
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
+
+  jsr:
+    name: Publish JSR
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 22
+          cache: npm
+      - name: Setup Deno
+        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        with:
+          deno-version: 2.6.7
+      - name: Install
+        run: npm ci
+      - name: Quality gates
+        run: npm run lint && npm test && npm run jsr:dry
+      - name: Publish to JSR
+        env:
+          JSR_TOKEN: ${{ secrets.JSR_TOKEN }}
+        run: |
+          if [ -n "${JSR_TOKEN}" ]; then
+            deno publish --token "${JSR_TOKEN}"
+          else
+            deno publish
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to Dir Archiver
 
+### Unreleased
+
+* Add tag-driven `Release` workflow to automate npm and JSR publication.
+* Add `jsr.json` manifest and `npm run jsr:dry` packaging check.
+* Update docs to reflect ESM-only usage and Node.js >=22 with Deno/Bun smoke support.
+
 ### 2.2.0 (January 28, 2026)
 
 * Migrate source to TypeScript with strict compiler options.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Compress a whole directory (including subdirectories) into a zip file, with opti
 
 ```sh
 $ npm install dir-archiver
+# or
+$ deno add jsr:@ismail-elkorchi/dir-archiver
 ```
 
-Requires Node.js >=18.
+Requires Node.js >=22 for npm usage. The package is ESM-only and smoke-tested on latest stable Deno and Bun.
 
 # Usage
 
@@ -19,7 +21,7 @@ Requires Node.js >=18.
 Quick start (async/await):
 
 ```javascript
-const DirArchiver = require('dir-archiver');
+import DirArchiver from 'dir-archiver';
 
 const archive = new DirArchiver(
   './my-project',
@@ -113,7 +115,7 @@ $ npm run build
 $ npm run lint
 ```
 
-Linting runs TypeScript typechecking and ESLint. CI runs lint and tests on Node 18/20/22 across Linux, macOS, and Windows.
+Linting runs TypeScript typechecking and ESLint. CI runs lint/tests on Node 22 across Linux, macOS, and Windows, plus Deno and Bun smoke tests.
 
 
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,0 +1,27 @@
+{
+  "name": "@ismail-elkorchi/dir-archiver",
+  "version": "2.2.0",
+  "license": "MIT",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "imports": {
+    "@ismail-elkorchi/bytefold/node/zip": "jsr:@ismail-elkorchi/bytefold/deno@^0.5.0"
+  },
+  "publish": {
+    "include": [
+      "LICENSE",
+      "README.md",
+      "CHANGELOG.md",
+      "src/index.ts",
+      "jsr.json",
+      "package.json"
+    ],
+    "exclude": [
+      "dist/**",
+      "test/**",
+      "node_modules/**",
+      ".github/**"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "files": [
     "LICENSE",
-    "dist"
+    "dist",
+    "jsr.json"
   ],
   "keywords": [
     "zip",
@@ -47,6 +48,7 @@
     "test:deno": "npm run build && deno run --allow-read --allow-write --allow-env --allow-sys test/deno-smoke.mjs",
     "test:bun": "npm run build && bun test/bun-smoke.mjs",
     "test:runtimes": "npm run test:deno && npm run test:bun",
+    "jsr:dry": "deno publish --dry-run --allow-dirty",
     "prepack": "npm run build"
   },
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,15 @@ interface ZipWriterFactory {
 
 let zipWriterPromise: Promise<ZipWriterFactory> | undefined;
 
+interface RuntimeProcessLike {
+	platform?: string;
+}
+
+const getRuntimePlatform = (): string | undefined => {
+	const runtimeProcess = ( globalThis as { process?: RuntimeProcessLike } ).process;
+	return typeof runtimeProcess?.platform === 'string' ? runtimeProcess.platform : undefined;
+};
+
 const loadZipWriter = (): Promise<ZipWriterFactory> => {
 	zipWriterPromise ??= import( '@ismail-elkorchi/bytefold/node/zip' )
 		.then( ( moduleExports ) => moduleExports.ZipWriter as ZipWriterFactory );
@@ -64,7 +73,7 @@ class DirArchiver {
 		this.followSymlinks = followSymlinks;
 		this.baseDirectory = path.basename( this.directoryPath );
 		this.visitedDirectories = new Set();
-		this.caseInsensitiveExcludes = process.platform === 'win32';
+		this.caseInsensitiveExcludes = getRuntimePlatform() === 'win32';
 
 		// Contains the excluded files and folders.
 		this.excludedPaths = new Set();


### PR DESCRIPTION
## Summary
- add tag-driven `Release` workflow for npm and JSR publication
- add `jsr.json` manifest and `npm run jsr:dry` packaging check
- make runtime platform detection resilient for JSR type-checking (`globalThis.process` guard)
- align README/changelog with ESM + Node 22 + Deno/Bun smoke reality

## Verification
- `npm run lint`
- `npm test`
- `npm run test:runtimes`
- `npm run jsr:dry`
