### PR TITLE
refactor: split bytefold runtime adapters for Node/Deno/Bun

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           JSR_TOKEN: ${{ secrets.JSR_TOKEN }}
         run: |
           if [ -n "${JSR_TOKEN}" ]; then
-            deno publish --token "${JSR_TOKEN}"
+            deno publish --sloppy-imports --token "${JSR_TOKEN}"
           else
-            deno publish
+            deno publish --sloppy-imports
           fi

--- a/jsr.json
+++ b/jsr.json
@@ -6,14 +6,16 @@
     ".": "./src/index.ts"
   },
   "imports": {
-    "@ismail-elkorchi/bytefold/node/zip": "jsr:@ismail-elkorchi/bytefold/deno@^0.5.0"
+    "@ismail-elkorchi/bytefold/node/zip": "jsr:@ismail-elkorchi/bytefold/deno@^0.6.0",
+    "@ismail-elkorchi/bytefold/deno": "jsr:@ismail-elkorchi/bytefold/deno@^0.6.0",
+    "@ismail-elkorchi/bytefold/bun": "jsr:@ismail-elkorchi/bytefold/bun@^0.6.0"
   },
   "publish": {
     "include": [
       "LICENSE",
       "README.md",
       "CHANGELOG.md",
-      "src/index.ts",
+      "src/**",
       "jsr.json",
       "package.json"
     ],

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test:deno": "npm run build && deno run --allow-read --allow-write --allow-env --allow-sys test/deno-smoke.mjs",
     "test:bun": "npm run build && bun test/bun-smoke.mjs",
     "test:runtimes": "npm run test:deno && npm run test:bun",
-    "jsr:dry": "deno publish --dry-run --allow-dirty",
+    "jsr:dry": "deno publish --dry-run --allow-dirty --sloppy-imports",
     "prepack": "npm run build"
   },
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,39 +2,41 @@
 
 import * as path from 'node:path';
 import * as fs from 'node:fs';
-
-interface ZipWriterLike {
-	add: (
-		name: string,
-		source: string
-	) => Promise<void>;
-	close: () => Promise<void>;
-}
-
-interface ZipWriterFactory {
-	toFile: (
-		path: string | URL,
-		options?: {
-			sinkSeekabilityPolicy?: 'auto' | 'on' | 'off';
-		}
-	) => Promise<ZipWriterLike>;
-}
-
-let zipWriterPromise: Promise<ZipWriterFactory> | undefined;
+import { loadRuntimeZipWriter } from './runtime/index.js';
+import type { ZipWriterLike } from './runtime/types.js';
 
 interface RuntimeProcessLike {
 	platform?: string;
 }
 
+interface DenoGlobalLike {
+	build?: {
+		os?: string;
+	};
+}
+
+interface BunGlobalLike {
+	platform?: string;
+}
+
 const getRuntimePlatform = (): string | undefined => {
 	const runtimeProcess = ( globalThis as { process?: RuntimeProcessLike } ).process;
-	return typeof runtimeProcess?.platform === 'string' ? runtimeProcess.platform : undefined;
-};
-
-const loadZipWriter = (): Promise<ZipWriterFactory> => {
-	zipWriterPromise ??= import( '@ismail-elkorchi/bytefold/node/zip' )
-		.then( ( moduleExports ) => moduleExports.ZipWriter as ZipWriterFactory );
-	return zipWriterPromise;
+	if ( typeof runtimeProcess?.platform === 'string' ) {
+		return runtimeProcess.platform;
+	}
+	const denoGlobal = ( globalThis as { Deno?: DenoGlobalLike } ).Deno;
+	const denoPlatform = denoGlobal?.build?.os;
+	if ( denoPlatform === 'windows' ) {
+		return 'win32';
+	}
+	if ( typeof denoPlatform === 'string' ) {
+		return denoPlatform;
+	}
+	const bunGlobal = ( globalThis as { Bun?: BunGlobalLike } ).Bun;
+	if ( typeof bunGlobal?.platform === 'string' ) {
+		return bunGlobal.platform;
+	}
+	return undefined;
 };
 
 interface ArchiveFileEntry {
@@ -245,11 +247,11 @@ class DirArchiver {
 		this.visitedDirectories.clear();
 		const filesToArchive = this.collectArchiveEntries( this.directoryPath );
 
-		const ZipWriter = await loadZipWriter();
+		const createZipWriter = await loadRuntimeZipWriter();
 		let writer: ZipWriterLike | undefined;
 
 		try {
-			writer = await ZipWriter.toFile( this.zipPath, {
+			writer = await createZipWriter( this.zipPath, {
 				// Keep deterministic entry ordering across platforms.
 				sinkSeekabilityPolicy: 'on'
 			} );

--- a/src/runtime/bun.ts
+++ b/src/runtime/bun.ts
@@ -1,0 +1,68 @@
+import type { CreateZipWriter, ZipWriterLike, ZipWriterOptions } from './types.js';
+
+interface BunZipWriterLike {
+	add: (
+		name: string,
+		source: Uint8Array | ArrayBuffer | ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>
+	) => Promise<void>;
+	close: () => Promise<void>;
+}
+
+interface BunZipWriterModule {
+	zipToFile?: (
+		path: string | URL,
+		options?: ZipWriterOptions
+	) => Promise<BunZipWriterLike>;
+}
+
+interface BunFileLike {
+	arrayBuffer: () => Promise<ArrayBuffer>;
+}
+
+interface BunGlobalLike {
+	file?: ( path: string | URL ) => BunFileLike;
+}
+
+let bunZipWriterPromise: Promise<CreateZipWriter> | undefined;
+
+const normalizeWriterOptions = ( options?: ZipWriterOptions ): ZipWriterOptions | undefined => {
+	if ( options?.sinkSeekabilityPolicy === 'on' ) {
+		return {
+			...options,
+			sinkSeekabilityPolicy: 'auto'
+		};
+	}
+	return options;
+};
+
+const readSourceAsUint8Array = async ( sourcePath: string ): Promise<Uint8Array> => {
+	const bunGlobal = ( globalThis as { Bun?: BunGlobalLike } ).Bun;
+	if ( typeof bunGlobal?.file !== 'function' ) {
+		throw new Error( 'Bun file API is unavailable.' );
+	}
+	const sourceFile = bunGlobal.file( sourcePath );
+	const sourceBytes = await sourceFile.arrayBuffer();
+	return new Uint8Array( sourceBytes );
+};
+
+export const loadBunZipWriter = async (): Promise<CreateZipWriter> => {
+	bunZipWriterPromise ??= import( '@ismail-elkorchi/bytefold/bun' )
+		.then( ( moduleExports ) => {
+			const zipToFile = ( moduleExports as BunZipWriterModule ).zipToFile;
+			if ( typeof zipToFile !== 'function' ) {
+				throw new Error( 'Bytefold bun zipToFile is unavailable.' );
+			}
+			return async ( filePath, options ) => {
+				const writer = await zipToFile( filePath, normalizeWriterOptions( options ) );
+				const wrappedWriter: ZipWriterLike = {
+					add: async ( name, sourcePath ) => {
+						const bytes = await readSourceAsUint8Array( sourcePath );
+						await writer.add( name, bytes );
+					},
+					close: () => writer.close()
+				};
+				return wrappedWriter;
+			};
+		} );
+	return bunZipWriterPromise;
+};

--- a/src/runtime/deno.ts
+++ b/src/runtime/deno.ts
@@ -1,0 +1,63 @@
+import type { CreateZipWriter, ZipWriterLike, ZipWriterOptions } from './types.js';
+
+interface DenoZipWriterLike {
+	add: (
+		name: string,
+		source: Uint8Array | ArrayBuffer | ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>
+	) => Promise<void>;
+	close: () => Promise<void>;
+}
+
+interface DenoZipWriterModule {
+	zipToFile?: (
+		path: string | URL,
+		options?: ZipWriterOptions
+	) => Promise<DenoZipWriterLike>;
+}
+
+interface DenoGlobalLike {
+	readFile?: ( path: string | URL ) => Promise<Uint8Array>;
+}
+
+let denoZipWriterPromise: Promise<CreateZipWriter> | undefined;
+
+const normalizeWriterOptions = ( options?: ZipWriterOptions ): ZipWriterOptions | undefined => {
+	if ( options?.sinkSeekabilityPolicy === 'on' ) {
+		return {
+			...options,
+			sinkSeekabilityPolicy: 'auto'
+		};
+	}
+	return options;
+};
+
+const getDenoReadFile = (): ( ( path: string | URL ) => Promise<Uint8Array> ) => {
+	const denoGlobal = ( globalThis as { Deno?: DenoGlobalLike } ).Deno;
+	if ( typeof denoGlobal?.readFile !== 'function' ) {
+		throw new Error( 'Deno readFile is unavailable.' );
+	}
+	return denoGlobal.readFile.bind( denoGlobal );
+};
+
+export const loadDenoZipWriter = async (): Promise<CreateZipWriter> => {
+	denoZipWriterPromise ??= import( '@ismail-elkorchi/bytefold/deno' )
+		.then( ( moduleExports ) => {
+			const zipToFile = ( moduleExports as DenoZipWriterModule ).zipToFile;
+			if ( typeof zipToFile !== 'function' ) {
+				throw new Error( 'Bytefold deno zipToFile is unavailable.' );
+			}
+			return async ( filePath, options ) => {
+				const readFile = getDenoReadFile();
+				const writer = await zipToFile( filePath, normalizeWriterOptions( options ) );
+				const wrappedWriter: ZipWriterLike = {
+					add: async ( name, sourcePath ) => {
+						const bytes = await readFile( sourcePath );
+						await writer.add( name, bytes );
+					},
+					close: () => writer.close()
+				};
+				return wrappedWriter;
+			};
+		} );
+	return denoZipWriterPromise;
+};

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,0 +1,50 @@
+import { loadBunZipWriter } from './bun.js';
+import { loadDenoZipWriter } from './deno.js';
+import { loadNodeZipWriter } from './node.js';
+import type { CreateZipWriter } from './types.js';
+
+type RuntimeKind = 'node' | 'deno' | 'bun';
+
+interface NodeProcessLike {
+	versions?: {
+		node?: string;
+	};
+}
+
+const hasDenoGlobal = (): boolean => typeof ( globalThis as { Deno?: unknown } ).Deno !== 'undefined';
+
+const hasBunGlobal = (): boolean => typeof ( globalThis as { Bun?: unknown } ).Bun !== 'undefined';
+
+const hasNodeProcess = (): boolean => {
+	const runtimeProcess = ( globalThis as { process?: NodeProcessLike } ).process;
+	return typeof runtimeProcess?.versions?.node === 'string';
+};
+
+const detectRuntime = (): RuntimeKind => {
+	if ( hasDenoGlobal() ) {
+		return 'deno';
+	}
+	if ( hasBunGlobal() ) {
+		return 'bun';
+	}
+	if ( hasNodeProcess() ) {
+		return 'node';
+	}
+	throw new Error( 'Unsupported runtime. Expected Node.js, Deno, or Bun.' );
+};
+
+let runtimeZipWriterPromise: Promise<CreateZipWriter> | undefined;
+
+export const loadRuntimeZipWriter = async (): Promise<CreateZipWriter> => {
+	runtimeZipWriterPromise ??= ( async () => {
+		const runtime = detectRuntime();
+		if ( runtime === 'deno' ) {
+			return loadDenoZipWriter();
+		}
+		if ( runtime === 'bun' ) {
+			return loadBunZipWriter();
+		}
+		return loadNodeZipWriter();
+	} )();
+	return runtimeZipWriterPromise;
+};

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -1,0 +1,21 @@
+import type { CreateZipWriter } from './types.js';
+
+interface NodeZipWriterModule {
+	ZipWriter?: {
+		toFile?: CreateZipWriter;
+	};
+}
+
+let nodeZipWriterPromise: Promise<CreateZipWriter> | undefined;
+
+export const loadNodeZipWriter = async (): Promise<CreateZipWriter> => {
+	nodeZipWriterPromise ??= import( '@ismail-elkorchi/bytefold/node/zip' )
+		.then( ( moduleExports ) => {
+			const ZipWriter = ( moduleExports as NodeZipWriterModule ).ZipWriter;
+			if ( ! ZipWriter || typeof ZipWriter.toFile !== 'function' ) {
+				throw new Error( 'Bytefold node ZipWriter.toFile is unavailable.' );
+			}
+			return ZipWriter.toFile.bind( ZipWriter );
+		} );
+	return nodeZipWriterPromise;
+};

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,0 +1,16 @@
+export interface ZipWriterLike {
+	add: (
+		name: string,
+		source: string
+	) => Promise<void>;
+	close: () => Promise<void>;
+}
+
+export interface ZipWriterOptions {
+	sinkSeekabilityPolicy?: 'auto' | 'on' | 'off';
+}
+
+export type CreateZipWriter = (
+	path: string | URL,
+	options?: ZipWriterOptions
+) => Promise<ZipWriterLike>;


### PR DESCRIPTION
## Summary
- split archive writer loading into runtime adapters under `src/runtime/` (`node`, `deno`, `bun`, selector, shared types)
- replace hardcoded `@ismail-elkorchi/bytefold/node/zip` loading with runtime-selected bytefold API
- keep shared archive traversal/core logic in `src/index.ts`
- update JSR config/import mappings and publish command for source-based publish with sloppy imports
- update release workflow JSR publish command to use `--sloppy-imports`

## Why
- enables cross-runtime execution on Node/Deno/Bun without pinning runtime writer behavior to Node-only APIs
- keeps deterministic entry order while adapting Deno/Bun writer contracts safely

## Verification
- `npm run lint`
- `npm test`
- `npm run test:runtimes`
- `npm run jsr:dry`
