### PR TITLE
Archive contract: rewrite dir-archiver v3 on bytefold

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,6 @@
 version: 2
+# Version updates are queue-limited here; security updates are triaged as a separate Dependabot channel.
+# See: repository security alerts / Dependabot security updates for vulnerability remediation flow.
 updates:
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  analyze:
+  analyze-security:
     name: Analyze (JavaScript/TypeScript)
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -31,14 +31,40 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Initialize CodeQL
+      - name: Initialize CodeQL (security lane)
         uses: github/codeql-action/init@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
         with:
           languages: javascript-typescript
+          queries: security-extended
       - name: Autobuild
         uses: github/codeql-action/autobuild@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
-      - name: Analyze
+      - name: Analyze security
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
         uses: github/codeql-action/analyze@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
         with:
-          category: /language:javascript-typescript
+          category: /language:javascript-typescript/security-extended
+
+  analyze-quality:
+    name: Analyze quality (JavaScript/TypeScript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    continue-on-error: true
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Initialize CodeQL (quality lane)
+        uses: github/codeql-action/init@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
+      - name: Analyze quality
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+        uses: github/codeql-action/analyze@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
+        with:
+          category: /language:javascript-typescript/security-and-quality

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,24 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Dependency review
+        uses: actions/dependency-review-action@05fe4576374b728f0c523d6a13d64c25081e0803 # v4.8.3

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,0 +1,85 @@
+name: Downstream Compatibility
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: downstream-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  downstream-released:
+    name: Downstream released
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Load runtime policy
+        id: runtime-policy
+        shell: bash
+        run: |
+          node -e "const fs=require('node:fs');const p=JSON.parse(fs.readFileSync('tools/runtime-versions.json','utf8'));fs.appendFileSync(process.env.GITHUB_OUTPUT,'node_pinned='+p.node.pinned+'\\n');"
+      - name: Setup Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: ${{ steps.runtime-policy.outputs.node_pinned }}
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Released dependency gate
+        run: npm run test:downstream:released
+      - name: Fail on tracked-file churn
+        shell: bash
+        run: |
+          if [[ -n "$(git status --porcelain=v1)" ]]; then
+            echo "Tracked files changed during downstream released run:"
+            git status --porcelain=v1
+            exit 1
+          fi
+
+  downstream-main:
+    name: Downstream main
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    continue-on-error: true
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Load runtime policy
+        id: runtime-policy
+        shell: bash
+        run: |
+          node -e "const fs=require('node:fs');const p=JSON.parse(fs.readFileSync('tools/runtime-versions.json','utf8'));fs.appendFileSync(process.env.GITHUB_OUTPUT,'node_pinned='+p.node.pinned+'\\n');"
+      - name: Setup Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: ${{ steps.runtime-policy.outputs.node_pinned }}
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Main-branch dependency gate
+        id: downstream_main
+        run: npm run test:downstream:main
+      - name: Open issue for downstream main failure
+        if: failure() && github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="downstream-main failure: ${GITHUB_SHA}"
+          body="Downstream main compatibility failed.\n\nRun: ${GH_RUN_URL}\nCommit: ${GITHUB_SHA}\nWorkflow: ${GITHUB_WORKFLOW}"
+          gh issue create --title "$title" --body "$body" --label "ci"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,68 +1,158 @@
 name: CI
 
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
 permissions:
   contents: read
 
-on:
-  pull_request:
-  push:
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  node:
-    name: Lint and Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [22]
-    steps:
-      - name: Checkout the git repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Install dependencies
-        run: npm ci
-      - name: Lint JavaScript
-        run: npm run lint
-      - name: Run tests
-        run: npm test
-
-  deno-smoke:
-    name: Deno smoke
+  linux-floor-check:
+    name: Linux floor check
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
-      - name: Checkout the git repository
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup Node.js
+      - name: Load runtime policy
+        id: runtime-policy
+        shell: bash
+        run: |
+          node -e "const fs=require('node:fs');const p=JSON.parse(fs.readFileSync('tools/runtime-versions.json','utf8'));fs.appendFileSync(process.env.GITHUB_OUTPUT,'node_floor='+p.node.floor+'\\n');fs.appendFileSync(process.env.GITHUB_OUTPUT,'deno_floor='+p.deno.floor+'\\n');fs.appendFileSync(process.env.GITHUB_OUTPUT,'bun_floor='+p.bun.floor+'\\n');"
+      - name: Setup Node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: 22
+          node-version: ${{ steps.runtime-policy.outputs.node_floor }}
+          cache: npm
       - name: Setup Deno
         uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:
-          deno-version: 2.6.7
-      - name: Install dependencies
-        run: npm ci
-      - name: Run Deno smoke
-        run: npm run test:deno
-
-  bun-smoke:
-    name: Bun smoke
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the git repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: 22
+          deno-version: ${{ steps.runtime-policy.outputs.deno_floor }}
       - name: Setup Bun
         uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
         with:
-          bun-version: 1.3.3
+          bun-version: ${{ steps.runtime-policy.outputs.bun_floor }}
       - name: Install dependencies
         run: npm ci
-      - name: Run Bun smoke
-        run: npm run test:bun
+      - name: One-command truth
+        run: npm run check
+      - name: Fail on tracked-file churn
+        shell: bash
+        run: |
+          if [[ -n "$(git status --porcelain=v1)" ]]; then
+            echo "Tracked files changed during CI run:"
+            git status --porcelain=v1
+            exit 1
+          fi
+
+  linux-check:
+    name: Linux check
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Load runtime policy
+        id: runtime-policy
+        shell: bash
+        run: |
+          node -e "const fs=require('node:fs');const p=JSON.parse(fs.readFileSync('tools/runtime-versions.json','utf8'));fs.appendFileSync(process.env.GITHUB_OUTPUT,'node_pinned='+p.node.pinned+'\\n');fs.appendFileSync(process.env.GITHUB_OUTPUT,'deno_pinned='+p.deno.pinned+'\\n');fs.appendFileSync(process.env.GITHUB_OUTPUT,'bun_pinned='+p.bun.pinned+'\\n');"
+      - name: Setup Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: ${{ steps.runtime-policy.outputs.node_pinned }}
+          cache: npm
+      - name: Setup Deno
+        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        with:
+          deno-version: ${{ steps.runtime-policy.outputs.deno_pinned }}
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+        with:
+          bun-version: ${{ steps.runtime-policy.outputs.bun_pinned }}
+      - name: Install dependencies
+        run: npm ci
+      - name: One-command truth
+        run: npm run check
+      - name: Fail on tracked-file churn
+        shell: bash
+        run: |
+          if [[ -n "$(git status --porcelain=v1)" ]]; then
+            echo "Tracked files changed during CI run:"
+            git status --porcelain=v1
+            exit 1
+          fi
+
+  macos-smoke:
+    name: macOS smoke
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Load runtime policy
+        id: runtime-policy
+        shell: bash
+        run: |
+          node -e "const fs=require('node:fs');const p=JSON.parse(fs.readFileSync('tools/runtime-versions.json','utf8'));fs.appendFileSync(process.env.GITHUB_OUTPUT,'node_pinned='+p.node.pinned+'\\n');"
+      - name: Setup Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: ${{ steps.runtime-policy.outputs.node_pinned }}
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm run test
+      - name: Fail on tracked-file churn
+        shell: bash
+        run: |
+          if [[ -n "$(git status --porcelain=v1)" ]]; then
+            echo "Tracked files changed during CI run:"
+            git status --porcelain=v1
+            exit 1
+          fi
+
+  windows-smoke:
+    name: Windows smoke
+    runs-on: windows-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Load runtime policy
+        id: runtime-policy
+        shell: bash
+        run: |
+          node -e "const fs=require('node:fs');const p=JSON.parse(fs.readFileSync('tools/runtime-versions.json','utf8'));fs.appendFileSync(process.env.GITHUB_OUTPUT,'node_pinned='+p.node.pinned+'\\n');"
+      - name: Setup Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: ${{ steps.runtime-policy.outputs.node_pinned }}
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm run test
+      - name: Fail on tracked-file churn
+        shell: bash
+        run: |
+          if [[ -n "$(git status --porcelain=v1)" ]]; then
+            echo "Tracked files changed during CI run:"
+            git status --porcelain=v1
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -19,28 +18,39 @@ jobs:
     name: Publish npm
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Load runtime policy
+        id: runtime-policy
+        shell: bash
+        run: |
+          node -e "const fs=require('node:fs');const p=JSON.parse(fs.readFileSync('tools/runtime-versions.json','utf8'));fs.appendFileSync(process.env.GITHUB_OUTPUT,'node_pinned='+p.node.pinned+'\\n');fs.appendFileSync(process.env.GITHUB_OUTPUT,'deno_pinned='+p.deno.pinned+'\\n');fs.appendFileSync(process.env.GITHUB_OUTPUT,'bun_pinned='+p.bun.pinned+'\\n');"
       - name: Setup Node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: 22
+          node-version: ${{ steps.runtime-policy.outputs.node_pinned }}
           registry-url: https://registry.npmjs.org
-          always-auth: true
           cache: npm
       - name: Setup Deno
         uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:
-          deno-version: 2.6.7
+          deno-version: ${{ steps.runtime-policy.outputs.deno_pinned }}
       - name: Setup Bun
         uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
         with:
-          bun-version: 1.3.3
+          bun-version: ${{ steps.runtime-policy.outputs.bun_pinned }}
       - name: Install
         run: npm ci
       - name: Quality gates
-        run: npm run lint && npm test && npm run test:runtimes
+        run: npm run check
+      - name: Downstream released gate
+        run: npm run test:downstream:released
+      - name: Downstream main gate
+        run: npm run test:downstream:main
       - name: Fail on tracked-file churn
         shell: bash
         run: |
@@ -50,30 +60,40 @@ jobs:
             exit 1
           fi
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public
 
   jsr:
     name: Publish JSR
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Load runtime policy
+        id: runtime-policy
+        shell: bash
+        run: |
+          node -e "const fs=require('node:fs');const p=JSON.parse(fs.readFileSync('tools/runtime-versions.json','utf8'));fs.appendFileSync(process.env.GITHUB_OUTPUT,'node_pinned='+p.node.pinned+'\\n');fs.appendFileSync(process.env.GITHUB_OUTPUT,'deno_pinned='+p.deno.pinned+'\\n');"
       - name: Setup Node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: 22
+          node-version: ${{ steps.runtime-policy.outputs.node_pinned }}
           cache: npm
       - name: Setup Deno
         uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:
-          deno-version: 2.6.7
+          deno-version: ${{ steps.runtime-policy.outputs.deno_pinned }}
       - name: Install
         run: npm ci
       - name: Quality gates
-        run: npm run lint && npm test && npm run jsr:dry
+        run: npm run check && npm run jsr:dry
+      - name: Downstream released gate
+        run: npm run test:downstream:released
+      - name: Downstream main gate
+        run: npm run test:downstream:main
       - name: Publish to JSR
         env:
           JSR_TOKEN: ${{ secrets.JSR_TOKEN }}

--- a/.github/workflows/runtime-latest.yml
+++ b/.github/workflows/runtime-latest.yml
@@ -1,0 +1,42 @@
+name: Runtime Latest (Non-blocking)
+
+on:
+  schedule:
+    - cron: "11 4 * * 2"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runtime-latest-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  latest-smoke:
+    name: Latest runtime smoke (informational)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node (latest stable)
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: current
+          cache: npm
+      - name: Setup Deno (latest stable)
+        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        with:
+          deno-version: latest
+      - name: Setup Bun (latest stable)
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+        with:
+          bun-version: latest
+      - name: Install
+        run: npm ci
+      - name: Runtime staleness policy
+        run: node ./scripts/runtime-staleness-check.mjs
+      - name: One-command truth
+        run: npm run check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,20 @@
 
 ### Unreleased
 
-* Add tag-driven `Release` workflow to automate npm and JSR publication.
-* Add `jsr.json` manifest and `npm run jsr:dry` packaging check.
-* Update docs to reflect ESM-only usage and Node.js >=22 with Deno/Bun smoke support.
+* No entries yet.
+
+### 3.0.0 (February 28, 2026)
+
+* Rewrite dir-archiver as a bytefold-backed orchestration layer over `open`, `detect`, `list`, `audit`, `extract`, `normalize`, and `write`.
+* Expand format support to the full bytefold `ArchiveFormat` surface (zip/tar/layered codecs).
+* Add runtime adapters for Node.js, Deno, and Bun with unified API behavior.
+* Add strict/agent extraction security enforcement and stable `DirArchiverError.code` contracts.
+* Add CLI v3 contract with schema-driven parsing via `argv-flags`, machine JSON mode, and explicit exit code semantics.
+* Add capability-derived runtime matrix tests, determinism fingerprints, and adversarial security fixtures.
+* Add downstream compatibility gates against released dependencies and `main` branches.
+* Enforce ESM-only, workflow-policy, docs-policy, and runtime-policy gates via `npm run check`.
+* Align dependency source to released `@ismail-elkorchi/bytefold@^0.7.2` (remove local/git-sha dependency path).
+* Bump runtime floor to Node.js >=24 and keep Deno/Bun support through dedicated runtime checks.
 
 ### 2.2.0 (January 28, 2026)
 

--- a/README.md
+++ b/README.md
@@ -1,127 +1,88 @@
-[![npm][npm-image]][npm-url] [![license][license-image]][license-url]
-[![changelog][changelog-image]][changelog-url]
+---
+role: overview
+audience: users
+source_of_truth: README.md
+update_triggers:
+  - public API changes
+  - CLI contract changes
+  - runtime support changes
+---
 
-# Dir Archiver
-Compress a whole directory (including subdirectories) into a zip file, with options to exclude specific files or directories.
+# dir-archiver
 
-# Installation
+`dir-archiver` v3 is a bytefold-backed archive orchestration layer for Node.js, Deno, and Bun.  
+ESM-only. Safety profiles: `compat | strict | agent`.
+
+## Install
+
+### npm
 
 ```sh
-$ npm install dir-archiver
-# or
-$ deno add jsr:@ismail-elkorchi/dir-archiver
+npm install dir-archiver
 ```
 
-Requires Node.js >=22 for npm usage. The package is ESM-only and smoke-tested on latest stable Deno and Bun.
+### JSR
 
-# Usage
-
-## API
-
-Quick start (async/await):
-
-```javascript
-import DirArchiver from 'dir-archiver';
-
-const archive = new DirArchiver(
-  './my-project',
-  './my-project.zip',
-  true,
-  ['node_modules', 'dist', 'nested/secret.txt'],
-  false
-);
-
-await archive.createZip();
+```sh
+deno add jsr:@ismail-elkorchi/dir-archiver
 ```
 
-Signature:
+## Quickstart (API)
 
 ```ts
-new DirArchiver(
-  directoryPath: string,
-  zipPath: string,
-  includeBaseDirectory?: boolean,
-  excludes?: string[],
-  followSymlinks?: boolean
-)
+import { write, detect, list, extract } from 'dir-archiver';
+
+await write('./project', './project.zip', {
+  format: 'zip',
+  includeBaseDirectory: true,
+  profile: 'strict'
+});
+
+const detected = await detect('./project.zip');
+const listed = await list('./project.zip');
+await extract('./project.zip', './out', { profile: 'strict' });
+
+console.log(detected.format, listed.entries.length);
 ```
 
-Parameters:
-- `directoryPath`: Root folder to archive (must exist).
-- `zipPath`: Destination zip file path (parent directory must exist).
-- `includeBaseDirectory`: When true, the archive contains the source folder as the top-level directory.
-- `excludes`: Names or relative paths to skip. Names without path separators match anywhere; use a relative path
-  (for example, `nested/file.txt`) to target a specific entry. Trailing slashes can target directories (for example, `cache/`).
-  Windows-style backslashes are accepted and normalized. Absolute paths inside the source tree are accepted and converted
-  to relative excludes. Matching is case-insensitive on Windows.
-- `followSymlinks`: Follow symlinks when traversing directories. Default: `false`.
+## Public operations
 
-`createZip()` returns a Promise that resolves with the zip path when the archive is finalized and rejects on failure.
-Zip entries always use forward slashes, regardless of OS, and are added in deterministic order.
+- `open(input, options)`
+- `detect(input, options)`
+- `list(input, options)`
+- `audit(input, options)`
+- `extract(input, destination, options)`
+- `normalize(input, destination, options)`
+- `write(source, destination, options)`
 
-## Command Line Interface
+Format surface matches bytefold `ArchiveFormat` support.  
+Directory + single-file codec requests are normalized to `tar.<codec>` (`gz`, `bz2`, `xz`, `zst`, `br`).
+
+## CLI
 
 ```sh
-Usage: dir-archiver --src <path-to-directory> --dest <path-to-file>.zip --includebasedir true|false --exclude folder-name file-name.extension
-
-Options:
-  --src             The path of the folder to archive.                            [string][required]
-  --dest            The path of the zip file to create.                           [string][required]
-  --includebasedir  Includes a base directory at the root of the archive.
-                    For example, if the root folder of your project is named
-                    "your-project", setting this option to true will create
-                    an archive that includes this base directory.
-                    If this option is set to false the archive created will
-                    unzip its content to the current directory.                               [bool]
-  --followsymlinks  Follow symlinks when traversing directories.                              [bool]
-  --exclude         A list with the names of the files and folders to exclude. Names without
-                    path separators match anywhere; use a relative path to target a specific
-                    entry. Windows-style backslashes are accepted and normalized.           [array]
+dir-archiver write --source ./project --output ./project.zip --format zip --json
+dir-archiver detect --input ./project.zip --json
+dir-archiver list --input ./project.zip --json
+dir-archiver audit --input ./project.zip --profile agent --json
+dir-archiver extract --input ./project.zip --output ./out --profile strict --json
+dir-archiver normalize --input ./project.zip --output ./normalized.zip --json
 ```
 
-Inline values are supported for flags (for example, `--includebasedir=true` or `--exclude=cache`).
+Exit codes:
 
-# CLI examples
+- `0` success
+- `1` operational failure
+- `2` usage/validation failure
 
-```sh
-# Basic
-dir-archiver --src ./my-project --dest ./my-project.zip
+## Security model
 
-# Include base directory and exclude node_modules anywhere
-dir-archiver --src ./my-project --dest ./my-project.zip --includebasedir=true --exclude node_modules
+- Archive extraction treats input as untrusted by default.
+- Traversal/absolute paths are blocked in strict/agent profiles.
+- See `SECURITY.md` and `docs/security-triage.md`.
 
-# Exclude a specific path
-dir-archiver --src ./my-project --dest ./my-project.zip --exclude nested/secret.txt
+## Docs
 
-# Windows-style excludes (backslashes are normalized)
-dir-archiver --src . --dest archive.zip --exclude .\\nested\\skip.txt
-
-# Follow symlinks
-dir-archiver --src ./my-project --dest ./my-project.zip --followsymlinks=true
-```
-
-# Testing
-
-```sh
-$ npm test
-```
-
-# Development
-
-```sh
-$ npm install
-$ npm run typecheck
-$ npm run build
-$ npm run lint
-```
-
-Linting runs TypeScript typechecking and ESLint. CI runs lint/tests on Node 22 across Linux, macOS, and Windows, plus Deno and Bun smoke tests.
-
-
-
-[changelog-image]: https://img.shields.io/badge/changelog-md-blue.svg?style=flat-square
-[changelog-url]: CHANGELOG.md
-[license-image]: https://img.shields.io/npm/l/dir-archiver.svg?style=flat-square
-[license-url]: LICENSE
-[npm-image]: https://img.shields.io/npm/v/dir-archiver.svg?style=flat-square
-[npm-url]: https://www.npmjs.com/package/dir-archiver
+- `docs/V3_CONTRACT.md`
+- `CHANGELOG.md`
+- `SECURITY.md`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,17 +1,17 @@
-# Security Policy
+# Security policy
 
-## Supported Versions
+## Reporting
 
-The latest release on `main` receives security updates.
+Report security issues through GitHub Security Advisories for this repository.
 
-## Reporting a Vulnerability
+## Handling model
 
-Please report suspected vulnerabilities privately by emailing `ismail.elkorchi@gmail.com`.
+- Archive inputs are treated as untrusted data by default.
+- `strict` and `agent` safety profiles are the baseline for audit and extraction safety checks.
+- Security triage inventory is maintained in `docs/security-triage.md`.
 
-Include:
+## Disclosure workflow
 
-- affected version and platform,
-- reproduction steps or proof-of-concept,
-- impact assessment.
-
-We will acknowledge receipt, triage, and provide a remediation timeline.
+1. Reproduce and classify impact.
+2. Patch with tests.
+3. Publish release notes and remediation guidance.

--- a/docs/V3_CONTRACT.md
+++ b/docs/V3_CONTRACT.md
@@ -1,0 +1,92 @@
+---
+role: contract
+audience: maintainers, contributors, users
+source_of_truth: docs/V3_CONTRACT.md
+update_triggers:
+  - public API changes
+  - format support changes
+  - security-profile behavior changes
+---
+
+# dir-archiver v3 contract
+
+This document is the source of truth for `dir-archiver` v3 behavior.
+
+## Runtime support
+
+- Node.js LTS (minimum aligned with bytefold `engines.node`).
+- Latest stable Deno.
+- Latest stable Bun.
+
+## Public operations
+
+- `open(input, options)`
+- `detect(input, options)`
+- `list(input, options)`
+- `audit(input, options)`
+- `extract(input, destination, options)`
+- `normalize(input, destination, options)`
+- `write(source, destination, options)`
+
+Profiles are passed through to bytefold (`compat | strict | agent`).
+
+## Format surface
+
+v3 accepts the full bytefold `ArchiveFormat` union:
+
+`zip`, `tar`, `tgz`, `tar.gz`, `gz`, `bz2`, `tar.bz2`, `zst`, `tar.zst`, `br`, `tar.br`, `xz`, `tar.xz`.
+
+### Directory input with single-file codec
+
+When `write()` receives a directory source and the requested format is a single-file codec:
+
+- `gz` → `tar.gz`
+- `bz2` → `tar.bz2`
+- `xz` → `tar.xz`
+- `zst` → `tar.zst`
+- `br` → `tar.br`
+
+This conversion is deterministic and reported via `WriteResult.wrappedDirectoryCodec`.
+
+## Determinism rules
+
+- Directory traversal order is lexicographic and stable.
+- Archive entry paths are normalized to `/`.
+- `normalize()` defaults to deterministic mode (`isDeterministic: true`).
+
+## Resource limits
+
+Extraction limits are explicit options:
+
+- `maxEntryBytes`
+- `maxTotalExtractedBytes`
+
+Budget overruns fail with stable code `DIRARCHIVER_RESOURCE_LIMIT`.
+
+## Security model
+
+- Extraction treats archive entries as untrusted.
+- Absolute paths, drive-prefixed paths, and traversal (`..`) are rejected with `DIRARCHIVER_PATH_TRAVERSAL`.
+- Strict/agent extraction runs an audit gate before writing files.
+- Hard links are rejected with `DIRARCHIVER_UNSUPPORTED_ENTRY`.
+- Symlinks are skipped unless explicitly enabled.
+
+## Error code stability
+
+Consumers must rely on `DirArchiverError.code`, not message text.
+Current stable codes:
+
+- `DIRARCHIVER_INVALID_SOURCE`
+- `DIRARCHIVER_INVALID_DESTINATION`
+- `DIRARCHIVER_PATH_TRAVERSAL`
+- `DIRARCHIVER_UNSUPPORTED_ENTRY`
+- `DIRARCHIVER_RESOURCE_LIMIT`
+- `DIRARCHIVER_RUNTIME_UNSUPPORTED`
+- `DIRARCHIVER_NORMALIZE_UNSUPPORTED`
+- `DIRARCHIVER_USAGE`
+
+## API surface snapshot oracle
+
+`test/api-snapshot.test.mjs` compares module exports with
+`test/fixtures/api-surface.v3.json`.
+Any intentional API change must update both the contract and snapshot.

--- a/docs/security-triage.md
+++ b/docs/security-triage.md
@@ -1,0 +1,36 @@
+---
+role: policy
+audience: maintainers, agents
+source_of_truth: docs/security-triage.md
+update_triggers:
+  - security alert workflow changes
+  - triage policy changes
+---
+
+# Security triage inventory
+
+This file tracks security findings for `dir-archiver` and the decision state for each finding.
+
+## Inventory schema
+
+Each finding record uses:
+
+```json
+{
+  "ruleId": "string",
+  "severity": "error|warning|note|critical|high|medium|low",
+  "state": "open|fixed|dismissed",
+  "file": "string",
+  "line": 0,
+  "firstSeen": "ISO-8601",
+  "lastSeen": "ISO-8601",
+  "owner": "string"
+}
+```
+
+## Source precedence
+
+1. GitHub Security UI inventory (authoritative while token scopes are limited).
+2. GitHub API inventory (`code-scanning/alerts`, `dependabot/alerts`) once scopes are available.
+
+Any temporary fallback to UI-only triage must be logged in private evidence (`tse-workbench`).

--- a/jsr.json
+++ b/jsr.json
@@ -1,14 +1,15 @@
 {
   "name": "@ismail-elkorchi/dir-archiver",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts"
   },
   "imports": {
-    "@ismail-elkorchi/bytefold/node/zip": "jsr:@ismail-elkorchi/bytefold/deno@^0.6.0",
-    "@ismail-elkorchi/bytefold/deno": "jsr:@ismail-elkorchi/bytefold/deno@^0.6.0",
-    "@ismail-elkorchi/bytefold/bun": "jsr:@ismail-elkorchi/bytefold/bun@^0.6.0"
+    "@ismail-elkorchi/bytefold": "jsr:@ismail-elkorchi/bytefold@^0.7.2",
+    "@ismail-elkorchi/bytefold/node": "jsr:@ismail-elkorchi/bytefold/node@^0.7.2",
+    "@ismail-elkorchi/bytefold/deno": "jsr:@ismail-elkorchi/bytefold/deno@^0.7.2",
+    "@ismail-elkorchi/bytefold/bun": "jsr:@ismail-elkorchi/bytefold/bun@^0.7.2"
   },
   "publish": {
     "include": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "dir-archiver",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dir-archiver",
-      "version": "2.2.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@ismail-elkorchi/bytefold": "github:Ismail-elkorchi/bytefold#7eb173157d22baef2d72e20f952273bf58f5a2a3",
-        "argv-flags": "^1.0.2"
+        "@ismail-elkorchi/bytefold": "^0.7.2",
+        "argv-flags": "^1.0.3"
       },
       "bin": {
         "dir-archiver": "dist/cli.js"
@@ -26,7 +26,29 @@
         "yauzl": "^3.2.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
+      }
+    },
+    "../bytefold": {
+      "name": "@ismail-elkorchi/bytefold",
+      "version": "0.7.2",
+      "license": "MIT",
+      "devDependencies": {
+        "@playwright/test": "1.58.2",
+        "@types/node": "^24.0.0",
+        "@typescript-eslint/eslint-plugin": "8.54.0",
+        "@typescript-eslint/parser": "8.54.0",
+        "esbuild": "^0.25.11",
+        "eslint": "9.39.2",
+        "eslint-plugin-eslint-comments": "3.2.0",
+        "eslint-plugin-promise": "7.2.1",
+        "eslint-plugin-regexp": "3.0.0",
+        "eslint-plugin-unicorn": "62.0.0",
+        "fast-check": "^4.5.3",
+        "typescript": "^5.5.4"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -284,13 +306,8 @@
       }
     },
     "node_modules/@ismail-elkorchi/bytefold": {
-      "version": "0.6.0",
-      "resolved": "git+ssh://git@github.com/Ismail-elkorchi/bytefold.git#7eb173157d22baef2d72e20f952273bf58f5a2a3",
-      "integrity": "sha512-3xev8WwqtigIxyn6NbXhlyOsfNG45qG/MHta1eHdlp8EhQjqrCvcqBP3TM6Z2K8ZIzmuOm5+a4OtyRQI2IRUGw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=24"
-      }
+      "resolved": "../bytefold",
+      "link": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -614,9 +631,9 @@
       "license": "Python-2.0"
     },
     "node_modules/argv-flags": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/argv-flags/-/argv-flags-1.0.2.tgz",
-      "integrity": "sha512-HBl1j4iwXWnAwvTN5ahHfuOO3ERZ/edWksdvXAaa6VRK/57M+QNUe0t1RwPxIgtmE3kcAWyyxJTjegT7QSAhZA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/argv-flags/-/argv-flags-1.0.3.tgz",
+      "integrity": "sha512-g7JENERmaoMTjxpl0OsUz6fx/97zYP3EzE5bUDgMKnvZ8ic6YnNreiG9IUEQFIZo6VFHJf8Tf/dfSoM0uliAPA==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -1759,9 +1776,21 @@
       "dev": true
     },
     "@ismail-elkorchi/bytefold": {
-      "version": "git+ssh://git@github.com/Ismail-elkorchi/bytefold.git#7eb173157d22baef2d72e20f952273bf58f5a2a3",
-      "integrity": "sha512-3xev8WwqtigIxyn6NbXhlyOsfNG45qG/MHta1eHdlp8EhQjqrCvcqBP3TM6Z2K8ZIzmuOm5+a4OtyRQI2IRUGw==",
-      "from": "@ismail-elkorchi/bytefold@github:Ismail-elkorchi/bytefold#7eb173157d22baef2d72e20f952273bf58f5a2a3"
+      "version": "file:../bytefold",
+      "requires": {
+        "@playwright/test": "1.58.2",
+        "@types/node": "^24.0.0",
+        "@typescript-eslint/eslint-plugin": "8.54.0",
+        "@typescript-eslint/parser": "8.54.0",
+        "esbuild": "^0.25.11",
+        "eslint": "9.39.2",
+        "eslint-plugin-eslint-comments": "3.2.0",
+        "eslint-plugin-promise": "7.2.1",
+        "eslint-plugin-regexp": "3.0.0",
+        "eslint-plugin-unicorn": "62.0.0",
+        "fast-check": "^4.5.3",
+        "typescript": "^5.5.4"
+      }
     },
     "@types/estree": {
       "version": "1.0.8",
@@ -1950,9 +1979,9 @@
       "dev": true
     },
     "argv-flags": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/argv-flags/-/argv-flags-1.0.2.tgz",
-      "integrity": "sha512-HBl1j4iwXWnAwvTN5ahHfuOO3ERZ/edWksdvXAaa6VRK/57M+QNUe0t1RwPxIgtmE3kcAWyyxJTjegT7QSAhZA=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/argv-flags/-/argv-flags-1.0.3.tgz",
+      "integrity": "sha512-g7JENERmaoMTjxpl0OsUz6fx/97zYP3EzE5bUDgMKnvZ8ic6YnNreiG9IUEQFIZo6VFHJf8Tf/dfSoM0uliAPA=="
     },
     "balanced-match": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,28 +29,6 @@
         "node": ">=24"
       }
     },
-    "../bytefold": {
-      "name": "@ismail-elkorchi/bytefold",
-      "version": "0.7.2",
-      "license": "MIT",
-      "devDependencies": {
-        "@playwright/test": "1.58.2",
-        "@types/node": "^24.0.0",
-        "@typescript-eslint/eslint-plugin": "8.54.0",
-        "@typescript-eslint/parser": "8.54.0",
-        "esbuild": "^0.25.11",
-        "eslint": "9.39.2",
-        "eslint-plugin-eslint-comments": "3.2.0",
-        "eslint-plugin-promise": "7.2.1",
-        "eslint-plugin-regexp": "3.0.0",
-        "eslint-plugin-unicorn": "62.0.0",
-        "fast-check": "^4.5.3",
-        "typescript": "^5.5.4"
-      },
-      "engines": {
-        "node": ">=24"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -306,8 +284,13 @@
       }
     },
     "node_modules/@ismail-elkorchi/bytefold": {
-      "resolved": "../bytefold",
-      "link": true
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@ismail-elkorchi/bytefold/-/bytefold-0.7.2.tgz",
+      "integrity": "sha512-knFkqPBGaBNIa90mxEL5sUYJb1QC/U5l6hgE+OueVwVcu62oaycqvhL+fnP0MWcSfCHxL0EMcYqNypyo5bfofg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=24"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1776,21 +1759,9 @@
       "dev": true
     },
     "@ismail-elkorchi/bytefold": {
-      "version": "file:../bytefold",
-      "requires": {
-        "@playwright/test": "1.58.2",
-        "@types/node": "^24.0.0",
-        "@typescript-eslint/eslint-plugin": "8.54.0",
-        "@typescript-eslint/parser": "8.54.0",
-        "esbuild": "^0.25.11",
-        "eslint": "9.39.2",
-        "eslint-plugin-eslint-comments": "3.2.0",
-        "eslint-plugin-promise": "7.2.1",
-        "eslint-plugin-regexp": "3.0.0",
-        "eslint-plugin-unicorn": "62.0.0",
-        "fast-check": "^4.5.3",
-        "typescript": "^5.5.4"
-      }
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@ismail-elkorchi/bytefold/-/bytefold-0.7.2.tgz",
+      "integrity": "sha512-knFkqPBGaBNIa90mxEL5sUYJb1QC/U5l6hgE+OueVwVcu62oaycqvhL+fnP0MWcSfCHxL0EMcYqNypyo5bfofg=="
     },
     "@types/estree": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dir-archiver",
-  "version": "2.2.0",
-  "description": "Compress a whole directory (including subdirectories) into a zip file, with options to exclude specific files, or directories.",
+  "version": "3.0.0",
+  "description": "Bytefold-backed archive orchestration for directories/files across Node.js, Deno, and Bun.",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
@@ -21,17 +21,21 @@
     "jsr.json"
   ],
   "keywords": [
-    "zip",
-    "compression",
     "archive",
-    "archiver",
-    "folder",
-    "directory",
-    "dir"
+    "bytefold",
+    "dir-archiver",
+    "compression",
+    "cli",
+    "esm",
+    "jsr",
+    "npm",
+    "deno",
+    "bun",
+    "directory"
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Ismail-elkorchi/dir-archiver.git"
+    "url": "https://github.com/Ismail-elkorchi/dir-archiver"
   },
   "author": {
     "name": "Ismail El Korchi",
@@ -44,19 +48,25 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "npm run typecheck && eslint . --max-warnings=0",
-    "test": "npm run build && node test/cli-args.js && node test/smoke.js && node test/cli.js",
+    "test": "npm run build && node --test test/api-snapshot.test.mjs test/operations.test.mjs test/cli.test.mjs test/matrix-node.test.mjs",
+    "test:security": "npm run build && node --test test/security.test.mjs",
+    "check": "node ./scripts/verify-runtime-versions.mjs && node ./scripts/workflow-policy-check.mjs && node ./scripts/esm-only-guard.mjs && node ./scripts/docs-policy-check.mjs && npm run lint && npm run test && npm run test:security && npm run test:runtimes",
     "test:deno": "npm run build && deno run --allow-read --allow-write --allow-env --allow-sys test/deno-smoke.mjs",
     "test:bun": "npm run build && bun test/bun-smoke.mjs",
-    "test:runtimes": "npm run test:deno && npm run test:bun",
+    "test:runtimes": "npm run test:deno && npm run test:bun && npm run test:runtimes:fingerprints",
+    "test:runtimes:fingerprints": "npm run build && node ./scripts/compare-runtime-fingerprints.mjs",
+    "jsr:score": "node ./scripts/jsr-score-gate.mjs",
+    "test:downstream:released": "npm run test",
+    "test:downstream:main": "npm install --no-save github:Ismail-elkorchi/bytefold#main github:Ismail-elkorchi/argv-flags#main && npm run test",
     "jsr:dry": "deno publish --dry-run --allow-dirty --sloppy-imports",
     "prepack": "npm run build"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "dependencies": {
-    "@ismail-elkorchi/bytefold": "github:Ismail-elkorchi/bytefold#7eb173157d22baef2d72e20f952273bf58f5a2a3",
-    "argv-flags": "^1.0.2"
+    "@ismail-elkorchi/bytefold": "^0.7.2",
+    "argv-flags": "^1.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/scripts/compare-runtime-fingerprints.mjs
+++ b/scripts/compare-runtime-fingerprints.mjs
@@ -1,0 +1,41 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const root = process.cwd();
+const tempDir = mkdtempSync(path.join(tmpdir(), 'dir-archiver-runtime-fp-'));
+const nodeOut = path.join(tempDir, 'node.json');
+const denoOut = path.join(tempDir, 'deno.json');
+const bunOut = path.join(tempDir, 'bun.json');
+
+try {
+  run([process.execPath, ['scripts/runtime-fingerprint.mjs', '--out', nodeOut]], 'node');
+  run(['deno', ['run', '--allow-read', '--allow-write', '--allow-env', '--allow-sys', 'scripts/runtime-fingerprint.mjs', '--out', denoOut]], 'deno');
+  run(['bun', ['scripts/runtime-fingerprint.mjs', '--out', bunOut]], 'bun');
+
+  const nodeResult = JSON.parse(readFileSync(nodeOut, 'utf8'));
+  const denoResult = JSON.parse(readFileSync(denoOut, 'utf8'));
+  const bunResult = JSON.parse(readFileSync(bunOut, 'utf8'));
+
+  const fingerprintSet = new Set([nodeResult.fingerprint, denoResult.fingerprint, bunResult.fingerprint]);
+  if (fingerprintSet.size !== 1) {
+    throw new Error(
+      `runtime fingerprint mismatch: node=${nodeResult.fingerprint} deno=${denoResult.fingerprint} bun=${bunResult.fingerprint}`
+    );
+  }
+
+  process.stdout.write(`runtime-fingerprints: ${nodeResult.fingerprint}\n`);
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
+}
+
+function run([command, args], label) {
+  const result = spawnSync(command, args, { cwd: root, encoding: 'utf8' });
+  if (result.status === 0) {
+    return;
+  }
+  const stderr = result.stderr || '';
+  const stdout = result.stdout || '';
+  throw new Error(`${label} fingerprint command failed (status=${result.status})\n${stdout}\n${stderr}`);
+}

--- a/scripts/docs-policy-check.mjs
+++ b/scripts/docs-policy-check.mjs
@@ -1,0 +1,85 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const policyPath = path.join(ROOT, 'tools', 'docs-policy.json');
+
+const run = async () => {
+  const policy = JSON.parse(await readFile(policyPath, 'utf8'));
+  const entrypoints = Array.isArray(policy.entrypoints) ? policy.entrypoints : [];
+  const symbolFiles = Array.isArray(policy.symbolFiles) ? policy.symbolFiles : [];
+  const minDocumentedSymbols = Number(policy.minDocumentedSymbols ?? 0);
+  const baselineMinDocumentedSymbols = Number(policy.baselineMinDocumentedSymbols ?? 0);
+
+  for (const relativePath of entrypoints) {
+    const source = await readFile(path.join(ROOT, relativePath), 'utf8');
+    if (!hasModuleDoc(source)) {
+      throw new Error(`entrypoint missing module docs: ${relativePath}`);
+    }
+  }
+
+  let documented = 0;
+  let total = 0;
+  for (const relativePath of symbolFiles) {
+    const source = await readFile(path.join(ROOT, relativePath), 'utf8');
+    const entries = collectExportedSymbols(source);
+    documented += entries.documented;
+    total += entries.total;
+  }
+
+  const ratio = total === 0 ? 1 : documented / total;
+  const threshold = Math.max(minDocumentedSymbols, baselineMinDocumentedSymbols);
+  process.stdout.write(`docs-policy: documented=${documented} total=${total} ratio=${ratio.toFixed(4)} threshold=${threshold}\n`);
+
+  if (ratio < threshold) {
+    throw new Error(`documented symbol ratio ${ratio.toFixed(4)} is below required ${threshold}`);
+  }
+};
+
+function hasModuleDoc(source) {
+  const lines = source.replace(/\r\n/g, '\n').split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    return trimmed.startsWith('/**');
+  }
+  return false;
+}
+
+function collectExportedSymbols(source) {
+  const normalized = source.replace(/\r\n/g, '\n');
+  const lines = normalized.split('\n');
+  let documented = 0;
+  let total = 0;
+
+  const exportPattern = /^\s*export\s+(?:declare\s+)?(?:const|function|class|interface|type|enum)\s+[A-Za-z_][A-Za-z0-9_]*/;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    if (!exportPattern.test(line)) continue;
+    total += 1;
+    if (hasDocCommentBefore(lines, index)) {
+      documented += 1;
+    }
+  }
+
+  return { documented, total };
+}
+
+function hasDocCommentBefore(lines, index) {
+  for (let cursor = index - 1; cursor >= 0 && cursor >= index - 8; cursor -= 1) {
+    const line = (lines[cursor] ?? '').trim();
+    if (line.length === 0) continue;
+    if (line.startsWith('/**') || line === '*/' || line.startsWith('* ')) {
+      return true;
+    }
+    if (!line.startsWith('//')) {
+      return false;
+    }
+  }
+  return false;
+}
+
+run().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/esm-only-guard.mjs
+++ b/scripts/esm-only-guard.mjs
@@ -1,0 +1,74 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const SOURCE_DIRS = ['src'];
+const ROOT_SOURCE_FILES = ['index.ts', 'mod.ts'];
+const CJS_PATTERN = /\brequire\s*\(|module\.exports|\bexports\./g;
+
+const run = async () => {
+  const targets = [];
+
+  for (const directory of SOURCE_DIRS) {
+    const absoluteDirectory = path.join(ROOT, directory);
+    await collectFiles(absoluteDirectory, targets);
+  }
+
+  for (const fileName of ROOT_SOURCE_FILES) {
+    const absolutePath = path.join(ROOT, fileName);
+    try {
+      const content = await readFile(absolutePath, 'utf8');
+      targets.push({ path: absolutePath, content });
+    } catch {
+      // Ignore absent optional root entrypoints.
+    }
+  }
+
+  const violations = [];
+  for (const file of targets) {
+    const lines = file.content.split('\n');
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index] ?? '';
+      if (!CJS_PATTERN.test(line)) {
+        continue;
+      }
+      CJS_PATTERN.lastIndex = 0;
+      const rel = path.relative(ROOT, file.path).replace(/\\/g, '/');
+      violations.push(`${rel}:${index + 1}: ${line.trim()}`);
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error('[esm-only-guard] CommonJS tokens are forbidden in source entrypoints:');
+    for (const violation of violations) {
+      console.error(`- ${violation}`);
+    }
+    process.exitCode = 1;
+  }
+};
+
+async function collectFiles(directoryPath, targets) {
+  let entries;
+  try {
+    entries = await readdir(directoryPath, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const entryPath = path.join(directoryPath, entry.name);
+    if (entry.isDirectory()) {
+      await collectFiles(entryPath, targets);
+      continue;
+    }
+    if (!entry.name.endsWith('.ts') && !entry.name.endsWith('.mts')) {
+      continue;
+    }
+    const content = await readFile(entryPath, 'utf8');
+    targets.push({ path: entryPath, content });
+  }
+}
+
+run().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/jsr-score-gate.mjs
+++ b/scripts/jsr-score-gate.mjs
@@ -1,0 +1,65 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+
+const run = async () => {
+  const jsr = JSON.parse(await readFile(path.join(ROOT, 'jsr.json'), 'utf8'));
+  const policy = JSON.parse(await readFile(path.join(ROOT, 'tools', 'docs-policy.json'), 'utf8'));
+
+  const jsrName = String(jsr.name ?? '');
+  const match = jsrName.match(/^@([^/]+)\/([^/]+)$/);
+  if (!match) {
+    throw new Error(`Invalid jsr package name: ${jsrName}`);
+  }
+  const scope = match[1];
+  const pkg = match[2];
+  if (!scope || !pkg) {
+    throw new Error(`Invalid jsr package name: ${jsrName}`);
+  }
+
+  const response = await fetch(`https://api.jsr.io/scopes/${scope}/packages/${pkg}/score`);
+  if (!response.ok) {
+    throw new Error(`JSR score API request failed: ${response.status}`);
+  }
+  const payload = await response.json();
+
+  const requiredBooleans = [
+    'hasDescription',
+    'hasReadme',
+    'hasReadmeExamples',
+    'allEntrypointsDocs',
+    'allFastCheck',
+    'hasProvenance',
+    'atLeastOneRuntimeCompatible',
+    'multipleRuntimesCompatible'
+  ];
+  for (const field of requiredBooleans) {
+    if (payload[field] !== true) {
+      throw new Error(`JSR score boolean failed: ${field}=false`);
+    }
+  }
+
+  const minDocumentedSymbols = Number(policy.minDocumentedSymbols ?? 0);
+  const percentageDocumentedSymbols = Number(payload.percentageDocumentedSymbols ?? 0);
+  if (percentageDocumentedSymbols < minDocumentedSymbols) {
+    throw new Error(
+      `JSR documented symbol ratio ${percentageDocumentedSymbols} is below policy ${minDocumentedSymbols}`
+    );
+  }
+
+  const targetTotal = Number(policy.targetTotal ?? 0);
+  const total = Number(payload.total ?? 0);
+  if (total < targetTotal) {
+    throw new Error(`JSR total ${total} is below policy target ${targetTotal}`);
+  }
+
+  process.stdout.write(
+    `jsr-score-gate: total=${total} documented=${percentageDocumentedSymbols} target=${targetTotal}\n`
+  );
+};
+
+run().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/runtime-fingerprint.mjs
+++ b/scripts/runtime-fingerprint.mjs
@@ -1,0 +1,104 @@
+import { createHash } from 'node:crypto';
+import { mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { extract, list, write } from '../dist/index.js';
+
+const args = parseArgs(process.argv.slice(2));
+const outPath = args.out;
+
+const run = async () => {
+  if (!outPath) {
+    throw new Error('runtime-fingerprint requires --out <path>');
+  }
+
+  const format = args.format ?? 'zip';
+  const tmpRoot = mkdtempSync(path.join(tmpdir(), 'dir-archiver-fingerprint-'));
+
+  try {
+    const sourceDir = path.join(tmpRoot, 'source');
+    mkdirSync(path.join(sourceDir, 'nested'), { recursive: true });
+    writeFileSync(path.join(sourceDir, 'root.txt'), 'root-content');
+    writeFileSync(path.join(sourceDir, 'nested', 'nested.txt'), 'nested-content');
+
+    const archivePath = path.join(tmpRoot, `bundle.${format.replace('/', '.')}`);
+    await write(sourceDir, archivePath, { format, includeBaseDirectory: true });
+    const listed = await list(archivePath, {});
+
+    const extractDir = path.join(tmpRoot, 'extracted');
+    await extract(archivePath, extractDir, { profile: 'strict' });
+
+    const entryDescriptors = listed.entries
+      .map((entry) => `${entry.name}:${entry.size}:${entry.isDirectory ? 'd' : 'f'}`)
+      .sort();
+    const extractedDescriptors = collectExtractedDescriptors(extractDir).sort();
+
+    const fingerprintInput = JSON.stringify({
+      format: listed.format,
+      entries: entryDescriptors,
+      extracted: extractedDescriptors
+    });
+    const fingerprint = createHash('sha256').update(fingerprintInput).digest('hex');
+
+    writeFileSync(
+      outPath,
+      `${JSON.stringify(
+        {
+          format,
+          detectedFormat: listed.format,
+          fingerprint,
+          entries: entryDescriptors,
+          extracted: extractedDescriptors
+        },
+        null,
+        2
+      )}\n`
+    );
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+};
+
+function collectExtractedDescriptors(rootDir) {
+  const descriptors = [];
+  visit(rootDir, '');
+  return descriptors;
+
+  function visit(currentPath, relativePrefix) {
+    const entries = readdirSync(currentPath);
+    for (const entry of entries) {
+      const absolutePath = path.join(currentPath, entry);
+      const relativePath = relativePrefix.length > 0 ? path.join(relativePrefix, entry) : entry;
+      const stats = statSync(absolutePath);
+      if (stats.isDirectory()) {
+        visit(absolutePath, relativePath);
+        continue;
+      }
+      const bytes = readFileSync(absolutePath);
+      const digest = createHash('sha256').update(bytes).digest('hex');
+      descriptors.push(`${relativePath.replace(/\\/g, '/')}:${digest}`);
+    }
+  }
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--out') {
+      options.out = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (token === '--format') {
+      options.format = argv[index + 1];
+      index += 1;
+    }
+  }
+  return options;
+}
+
+run().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/runtime-staleness-check.mjs
+++ b/scripts/runtime-staleness-check.mjs
@@ -1,0 +1,111 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const run = async () => {
+  const ROOT = process.cwd();
+  const policyPath = path.join(ROOT, 'tools', 'runtime-versions.json');
+  const policy = JSON.parse(await readFile(policyPath, 'utf8'));
+
+  const runtimeConfigs = [
+    { runtime: 'node', latest: latestNodeLts },
+    { runtime: 'deno', latest: latestDenoStable },
+    { runtime: 'bun', latest: latestBunStable }
+  ];
+
+  const messages = [];
+  const violations = [];
+
+  for (const target of runtimeConfigs) {
+    const config = policy[target.runtime];
+    if (!config || typeof config.pinned !== 'string') continue;
+
+    const pinned = parseSemver(config.pinned);
+    const floor = parseSemver(config.floor);
+    const latest = await target.latest();
+    const tolerance = policy.policy?.staleness?.[target.runtime] ?? {};
+    const maxMajorLag = Number.isInteger(tolerance.maxMajorLag) ? tolerance.maxMajorLag : 0;
+    const maxMinorLag = Number.isInteger(tolerance.maxMinorLag) ? tolerance.maxMinorLag : 0;
+
+    if (!pinned || !latest) {
+      violations.push(`${target.runtime}: invalid pinned or latest version`);
+      continue;
+    }
+
+    messages.push(`${target.runtime}: floor=${floor ? floor.raw : 'n/a'} pinned=${pinned.raw} latest=${latest.raw}`);
+
+    const majorLag = latest.major - pinned.major;
+    const minorLag = latest.major === pinned.major ? latest.minor - pinned.minor : 0;
+    if (majorLag > maxMajorLag) {
+      violations.push(`${target.runtime}: major lag ${majorLag} exceeds policy ${maxMajorLag}`);
+      continue;
+    }
+    if (majorLag === 0 && minorLag > maxMinorLag) {
+      violations.push(`${target.runtime}: minor lag ${minorLag} exceeds policy ${maxMinorLag}`);
+    }
+  }
+
+  for (const message of messages) {
+    process.stdout.write(`${message}\n`);
+  }
+
+  if (violations.length > 0) {
+    process.stderr.write('[runtime-staleness] policy violations detected:\n');
+    for (const violation of violations) {
+      process.stderr.write(`- ${violation}\n`);
+    }
+    process.exitCode = 1;
+  }
+};
+
+async function latestNodeLts() {
+  const response = await fetch('https://nodejs.org/dist/index.json');
+  if (!response.ok) throw new Error(`node index fetch failed: ${response.status}`);
+  const payload = await response.json();
+  if (!Array.isArray(payload)) return null;
+  for (const item of payload) {
+    if (!item || typeof item !== 'object') continue;
+    if (!item.lts) continue;
+    const version = parseSemver(item.version);
+    if (version) return version;
+  }
+  return null;
+}
+
+async function latestDenoStable() {
+  return latestGitHubTag('denoland', 'deno');
+}
+
+async function latestBunStable() {
+  return latestGitHubTag('oven-sh', 'bun');
+}
+
+async function latestGitHubTag(owner, repo) {
+  const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/releases/latest`, {
+    headers: {
+      'User-Agent': 'runtime-staleness-check'
+    }
+  });
+  if (!response.ok) throw new Error(`${owner}/${repo} latest release fetch failed: ${response.status}`);
+  const payload = await response.json();
+  const tag = typeof payload.tag_name === 'string' ? payload.tag_name : '';
+  return parseSemver(tag);
+}
+
+function parseSemver(value) {
+  const match = String(value).trim().match(/^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
+  if (!match) return null;
+  const major = match[1] ?? '0';
+  const minor = match[2] ?? '0';
+  const patch = match[3] ?? '0';
+  return {
+    major: Number(major),
+    minor: Number(minor),
+    patch: Number(patch),
+    raw: `${major}.${minor}.${patch}`
+  };
+}
+
+run().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/verify-runtime-versions.mjs
+++ b/scripts/verify-runtime-versions.mjs
@@ -1,0 +1,77 @@
+import { readFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+const run = async () => {
+  const ROOT = process.cwd();
+  const policyPath = path.join(ROOT, 'tools', 'runtime-versions.json');
+  const policy = JSON.parse(await readFile(policyPath, 'utf8'));
+
+  const targets = [
+    { runtime: 'node', command: [process.execPath, ['--version']], parser: parseNodeVersion },
+    { runtime: 'deno', command: ['deno', ['--version']], parser: parseDenoVersion },
+    { runtime: 'bun', command: ['bun', ['--version']], parser: parseBunVersion }
+  ];
+
+  for (const target of targets) {
+    const rule = policy[target.runtime];
+    if (!rule || typeof rule.floor !== 'string') continue;
+    const output = getVersionOutput(target.runtime, target.command[0], target.command[1], rule.floor);
+    const actual = target.parser(output);
+    const required = parseSemver(rule.floor);
+    if (!actual || !required) {
+      throw new Error(`${target.runtime} version parse failed (required ${rule.floor}).`);
+    }
+    if (compareSemver(actual, required) < 0) {
+      throw new Error(`${target.runtime} ${actual.raw} does not satisfy floor ${rule.floor}.`);
+    }
+  }
+};
+
+function getVersionOutput(runtime, command, args, requiredFloor) {
+  const result = spawnSync(command, args, { encoding: 'utf8' });
+  if (result.status === 0) {
+    return result.stdout || result.stderr || '';
+  }
+  if (result.error) {
+    throw new Error(`${runtime} is missing; required floor ${requiredFloor}`);
+  }
+  throw new Error(`${runtime} version check failed: ${result.stderr || 'unknown error'}`);
+}
+
+function parseNodeVersion(output) {
+  const match = output.match(/v(\d+\.\d+\.\d+)/);
+  return match ? parseSemver(match[1]) : null;
+}
+
+function parseDenoVersion(output) {
+  const match = output.match(/deno\s+(\d+\.\d+\.\d+)/i);
+  return match ? parseSemver(match[1]) : null;
+}
+
+function parseBunVersion(output) {
+  const match = output.match(/(\d+\.\d+\.\d+)/);
+  return match ? parseSemver(match[1]) : null;
+}
+
+function parseSemver(value) {
+  const match = String(value).trim().match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    raw: `${match[1]}.${match[2]}.${match[3]}`
+  };
+}
+
+function compareSemver(a, b) {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  return a.patch - b.patch;
+}
+
+run().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/workflow-policy-check.mjs
+++ b/scripts/workflow-policy-check.mjs
@@ -1,0 +1,82 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const WORKFLOWS_DIR = path.join(ROOT, '.github', 'workflows');
+const mutableRefPattern = /uses:\s*[^#\n]+@(v\d+(?:\.\d+)*|main|master)\b/g;
+const pullRequestTargetPattern = /(^|\n)\s*pull_request_target\s*:/m;
+const topLevelPermissionsPattern = /^permissions:\s*$/m;
+
+function readTopLevelPermissionsBlock(source) {
+  const lines = source.split('\n');
+  const startIndex = lines.findIndex((line) => line === 'permissions:');
+  if (startIndex === -1) {
+    return null;
+  }
+  const collected = [];
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    if (line.length === 0) {
+      if (collected.length > 0) {
+        break;
+      }
+      continue;
+    }
+    if (!line.startsWith('  ')) {
+      break;
+    }
+    collected.push(line);
+  }
+  return collected.join('\n');
+}
+
+const run = async () => {
+  const workflowFiles = (await readdir(WORKFLOWS_DIR))
+    .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+    .sort((left, right) => left.localeCompare(right));
+
+  const violations = [];
+
+  for (const fileName of workflowFiles) {
+    const workflowPath = path.join(WORKFLOWS_DIR, fileName);
+    const source = (await readFile(workflowPath, 'utf8')).replace(/\r\n/g, '\n');
+
+    const mutableMatch = source.match(mutableRefPattern);
+    if (mutableMatch) {
+      violations.push(`${fileName}: mutable action ref(s): ${mutableMatch.join(', ')}`);
+    }
+
+    if (!topLevelPermissionsPattern.test(source)) {
+      violations.push(`${fileName}: missing top-level permissions block`);
+    }
+
+    if (pullRequestTargetPattern.test(source)) {
+      violations.push(`${fileName}: forbidden pull_request_target trigger`);
+    }
+
+    const permissionsBlock = readTopLevelPermissionsBlock(source);
+    if (!permissionsBlock) {
+      continue;
+    }
+    const writeLines = permissionsBlock
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.endsWith(': write'));
+    if (writeLines.length > 0) {
+      violations.push(`${fileName}: top-level permissions must stay read-only (found ${writeLines.join(', ')})`);
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error('[workflow-policy] violations detected:');
+    for (const violation of violations) {
+      console.error(`- ${violation}`);
+    }
+    process.exitCode = 1;
+  }
+};
+
+run().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,94 +1,287 @@
 import type { Schema } from 'argv-flags';
+import type { ArchiveFormat, ArchiveProfile } from './types.js';
+
+const SUPPORTED_COMMANDS = new Set(['open', 'detect', 'list', 'audit', 'extract', 'normalize', 'write']);
+
+const SUPPORTED_FORMATS = new Set<ArchiveFormat>([
+  'zip',
+  'tar',
+  'tgz',
+  'tar.gz',
+  'gz',
+  'bz2',
+  'tar.bz2',
+  'zst',
+  'tar.zst',
+  'br',
+  'tar.br',
+  'xz',
+  'tar.xz'
+]);
+
+const SUPPORTED_PROFILES = new Set<ArchiveProfile>(['compat', 'strict', 'agent']);
 
 const CLI_SCHEMA = {
-	src: {
-		type: 'string',
-		flags: [ '--src' ],
-		required: true
-	},
-	dest: {
-		type: 'string',
-		flags: [ '--dest' ],
-		required: true
-	},
-	includebasedir: {
-		type: 'boolean',
-		flags: [ '--includebasedir' ],
-		default: false
-	},
-	followsymlinks: {
-		type: 'boolean',
-		flags: [ '--followsymlinks' ],
-		default: false
-	},
-	exclude: {
-		type: 'array',
-		flags: [ '--exclude' ],
-		default: [] as string[]
-	}
+  source: {
+    type: 'string',
+    flags: ['--source', '--src']
+  },
+  input: {
+    type: 'string',
+    flags: ['--input', '-i']
+  },
+  output: {
+    type: 'string',
+    flags: ['--output', '--dest', '-o']
+  },
+  format: {
+    type: 'string',
+    flags: ['--format']
+  },
+  profile: {
+    type: 'string',
+    flags: ['--profile'],
+    default: 'strict'
+  },
+  json: {
+    type: 'boolean',
+    flags: ['--json'],
+    default: false
+  },
+  includeBaseDirectory: {
+    type: 'boolean',
+    flags: ['--include-base-directory', '--includebasedir'],
+    default: false
+  },
+  followSymlinks: {
+    type: 'boolean',
+    flags: ['--follow-symlinks', '--followsymlinks'],
+    default: false
+  },
+  exclude: {
+    type: 'array',
+    flags: ['--exclude'],
+    default: [] as string[]
+  },
+  allowSymlinks: {
+    type: 'boolean',
+    flags: ['--allow-symlinks'],
+    default: false
+  },
+  allowHardlinks: {
+    type: 'boolean',
+    flags: ['--allow-hardlinks'],
+    default: false
+  },
+  maxEntryBytes: {
+    type: 'number',
+    flags: ['--max-entry-bytes']
+  },
+  maxTotalExtractedBytes: {
+    type: 'number',
+    flags: ['--max-total-extracted-bytes']
+  }
 } as const satisfies Schema;
 
+export type CliCommand = 'open' | 'detect' | 'list' | 'audit' | 'extract' | 'normalize' | 'write';
+
 export interface ParsedCliArgs {
-	directoryPath: string | undefined;
-	zipPath: string | undefined;
-	includeBaseDirectory: boolean;
-	followSymlinks: boolean;
-	excludes: string[];
-	hasRequiredPaths: boolean;
+  ok: boolean;
+  issues: { code: string; message: string }[];
+  command: CliCommand | undefined;
+  input: string | undefined;
+  source: string | undefined;
+  output: string | undefined;
+  format: ArchiveFormat | undefined;
+  profile: ArchiveProfile;
+  json: boolean;
+  includeBaseDirectory: boolean;
+  followSymlinks: boolean;
+  exclude: string[];
+  allowSymlinks: boolean;
+  allowHardlinks: boolean;
+  maxEntryBytes: number | undefined;
+  maxTotalExtractedBytes: number | undefined;
 }
+
+type ParseArgsFn = (
+  schema: Schema,
+  options?: {
+    argv?: readonly string[];
+    allowUnknown?: boolean;
+    stopAtDoubleDash?: boolean;
+  }
+) => {
+  values: Record<string, unknown>;
+  rest: string[];
+  issues: {
+    code: string;
+    message: string;
+  }[];
+  ok: boolean;
+};
 
 let parseArgsPromise: Promise<ParseArgsFn> | undefined;
 
-type ParseArgsFn = (
-	schema: Schema,
-	options?: {
-		argv?: readonly string[];
-		allowUnknown?: boolean;
-		stopAtDoubleDash?: boolean;
-	}
-) => {
-	values: Record<string, unknown>;
-};
-
 const loadParseArgs = (): Promise<ParseArgsFn> => {
-	parseArgsPromise ??= import( 'argv-flags' ).then( ( argvFlagsModule ) => argvFlagsModule.default as ParseArgsFn );
-	return parseArgsPromise;
+  parseArgsPromise ??= import('argv-flags').then((moduleExports) => moduleExports.default as ParseArgsFn);
+  return parseArgsPromise;
 };
 
-const toString = ( value: unknown ): string | undefined => {
-	return typeof value === 'string' ? value : undefined;
+export const parseCliArgs = async (argv: readonly string[]): Promise<ParsedCliArgs> => {
+  const parseArgs = await loadParseArgs();
+  const parsed = parseArgs(CLI_SCHEMA, {
+    argv: [...argv]
+  });
+
+  const issues = parsed.issues.map((issue) => ({
+    code: issue.code,
+    message: issue.message
+  }));
+
+  const values = parsed.values;
+  const commandToken = parsed.rest[0];
+  const command = resolveCommand(commandToken, values, issues);
+  const profile = resolveProfile(values['profile'], issues);
+  const format = resolveFormat(values['format'], issues);
+
+  const source = toOptionalString(values['source']);
+  const input = toOptionalString(values['input']);
+  const output = toOptionalString(values['output']);
+
+  validateCommandRequirements(command, { source, input, output }, issues);
+
+  return {
+    ok: issues.length === 0,
+    issues,
+    command,
+    source,
+    input,
+    output,
+    format,
+    profile,
+    json: values['json'] === true,
+    includeBaseDirectory: values['includeBaseDirectory'] === true,
+    followSymlinks: values['followSymlinks'] === true,
+    exclude: toStringArray(values['exclude']),
+    allowSymlinks: values['allowSymlinks'] === true,
+    allowHardlinks: values['allowHardlinks'] === true,
+    maxEntryBytes: toOptionalNumber(values['maxEntryBytes']),
+    maxTotalExtractedBytes: toOptionalNumber(values['maxTotalExtractedBytes'])
+  };
 };
 
-const toBoolean = ( value: unknown ): boolean => {
-	return value === true;
+const resolveCommand = (
+  commandToken: string | undefined,
+  values: Record<string, unknown>,
+  issues: { code: string; message: string }[]
+): CliCommand | undefined => {
+  if (typeof commandToken === 'string' && SUPPORTED_COMMANDS.has(commandToken)) {
+    return commandToken as CliCommand;
+  }
+
+  if (typeof commandToken === 'string' && commandToken.length > 0) {
+    issues.push({
+      code: 'USAGE',
+      message: `Unknown command "${commandToken}".`
+    });
+    return undefined;
+  }
+
+  const hasSource = typeof values['source'] === 'string';
+  const hasOutput = typeof values['output'] === 'string';
+  if (hasSource && hasOutput) {
+    return 'write';
+  }
+
+  issues.push({
+    code: 'USAGE',
+    message: 'Missing command.'
+  });
+  return undefined;
 };
 
-const toStringArray = ( value: unknown ): string[] => {
-	if ( ! Array.isArray( value ) ) {
-		return [];
-	}
-	return value.filter( ( entry ): entry is string => typeof entry === 'string' );
+const resolveProfile = (
+  value: unknown,
+  issues: { code: string; message: string }[]
+): ArchiveProfile => {
+  const normalized = typeof value === 'string' ? value : 'strict';
+  if (!SUPPORTED_PROFILES.has(normalized as ArchiveProfile)) {
+    issues.push({
+      code: 'INVALID_VALUE',
+      message: `Unsupported profile "${String(value)}".`
+    });
+    return 'strict';
+  }
+  return normalized as ArchiveProfile;
 };
 
-export const parseCliArgs = async ( argv: readonly string[] ): Promise<ParsedCliArgs> => {
-	const parseArgs = await loadParseArgs();
-	const parsed = parseArgs( CLI_SCHEMA, {
-		argv: [ ...argv ],
-		allowUnknown: true
-	} );
+const resolveFormat = (
+  value: unknown,
+  issues: { code: string; message: string }[]
+): ArchiveFormat | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  if (!SUPPORTED_FORMATS.has(value as ArchiveFormat)) {
+    issues.push({
+      code: 'INVALID_VALUE',
+      message: `Unsupported format "${value}".`
+    });
+    return undefined;
+  }
+  return value as ArchiveFormat;
+};
 
-	const directoryPath = toString( parsed.values[ 'src' ] );
-	const zipPath = toString( parsed.values[ 'dest' ] );
-	const includeBaseDirectory = toBoolean( parsed.values[ 'includebasedir' ] );
-	const followSymlinks = toBoolean( parsed.values[ 'followsymlinks' ] );
-	const excludes = toStringArray( parsed.values[ 'exclude' ] );
+const validateCommandRequirements = (
+  command: CliCommand | undefined,
+  values: {
+    source: string | undefined;
+    input: string | undefined;
+    output: string | undefined;
+  },
+  issues: { code: string; message: string }[]
+): void => {
+  if (!command) {
+    return;
+  }
 
-	return {
-		directoryPath,
-		zipPath,
-		includeBaseDirectory,
-		followSymlinks,
-		excludes,
-		hasRequiredPaths: typeof directoryPath === 'string' && typeof zipPath === 'string'
-	};
+  if (command === 'write') {
+    if (!values.source) {
+      issues.push({ code: 'REQUIRED', message: 'write requires --source/--src.' });
+    }
+    if (!values.output) {
+      issues.push({ code: 'REQUIRED', message: 'write requires --output/--dest.' });
+    }
+    return;
+  }
+
+  if (command === 'extract' || command === 'normalize') {
+    if (!values.input) {
+      issues.push({ code: 'REQUIRED', message: `${command} requires --input.` });
+    }
+    if (!values.output) {
+      issues.push({ code: 'REQUIRED', message: `${command} requires --output.` });
+    }
+    return;
+  }
+
+  if (!values.input) {
+    issues.push({ code: 'REQUIRED', message: `${command} requires --input.` });
+  }
+};
+
+const toOptionalString = (value: unknown): string | undefined => {
+  return typeof value === 'string' ? value : undefined;
+};
+
+const toStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === 'string');
+};
+
+const toOptionalNumber = (value: unknown): number | undefined => {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,47 +1,154 @@
 #!/usr/bin/env node
 
-import DirArchiver from './index.js';
+import { audit, detect, extract, list, normalize, open, write } from './index.js';
+import { DirArchiverError } from './errors.js';
 import { parseCliArgs } from './cli-args.js';
 
-const usage = ` Dir Archiver could not be executed. Some arguments are missing.
+const usage = `Usage:
+  dir-archiver write --source <path> --output <archive> [--format <format>] [--include-base-directory] [--exclude <path>...]
+  dir-archiver detect --input <archive>
+  dir-archiver list --input <archive>
+  dir-archiver audit --input <archive> [--profile compat|strict|agent]
+  dir-archiver extract --input <archive> --output <directory> [--profile compat|strict|agent] [--max-entry-bytes <n>] [--max-total-extracted-bytes <n>]
+  dir-archiver normalize --input <archive> --output <archive> [--profile compat|strict|agent]
 
-    Options:
-      --src            The path of the folder to archive.                            [string][required]
-      --dest           The path of the zip file to create.                           [string][required]
-      --includebasedir Includes a base directory at the root of the archive.
-                       For example, if the root folder of your project is named
-                       "your-project", setting this option to true will create
-                       an archive that includes this base directory.
-                       If this option is set to false the archive created will
-                       unzip its content to the current directory.                               [bool]
-      --followsymlinks Follow symlinks when traversing directories.                              [bool]
-      --exclude        A list with the names of the files and folders to exclude.               [array]`;
+Common options:
+  --format <format>                     zip|tar|tgz|tar.gz|gz|bz2|tar.bz2|zst|tar.zst|br|tar.br|xz|tar.xz
+  --profile <profile>                   compat|strict|agent
+  --json                                emit machine-readable JSON
+  --allow-symlinks                      enable symlink extraction
+  --allow-hardlinks                     enable hardlink extraction (currently unsupported)
+`;
 
-const run = async (): Promise<void> => {
-	const parsedArgs = await parseCliArgs( process.argv.slice( 2 ) );
+const run = async (): Promise<number> => {
+  const parsed = await parseCliArgs(process.argv.slice(2));
+  const command = parsed.command;
+  if (!parsed.ok || !command) {
+    const payload = {
+      schemaVersion: '1',
+      code: 'DIRARCHIVER_USAGE',
+      message: 'Invalid CLI arguments.',
+      issues: parsed.issues
+    };
+    if (parsed.json) {
+      console.log(JSON.stringify(payload));
+    } else {
+      console.error(usage);
+      for (const issue of parsed.issues) {
+        console.error(`- [${issue.code}] ${issue.message}`);
+      }
+    }
+    return 2;
+  }
 
-	if (
-		! parsedArgs.hasRequiredPaths
-		|| typeof parsedArgs.directoryPath !== 'string'
-		|| typeof parsedArgs.zipPath !== 'string'
-	) {
-		console.log( usage );
-		process.exitCode = 1;
-		return;
-	}
+  const commonOptions = {
+    profile: parsed.profile,
+    ...(parsed.format ? { format: parsed.format } : {})
+  };
 
-	const archive = new DirArchiver(
-		parsedArgs.directoryPath,
-		parsedArgs.zipPath,
-		parsedArgs.includeBaseDirectory,
-		parsedArgs.excludes,
-		parsedArgs.followSymlinks
-	);
-	await archive.createZip();
+  switch (command) {
+    case 'write': {
+      const result = await write(
+        requireString(parsed.source, 'write requires --source/--src'),
+        requireString(parsed.output, 'write requires --output/--dest'),
+        {
+          ...commonOptions,
+          includeBaseDirectory: parsed.includeBaseDirectory,
+          followSymlinks: parsed.followSymlinks,
+          exclude: parsed.exclude
+        }
+      );
+      outputResult(parsed.json, result);
+      return 0;
+    }
+    case 'open': {
+      const reader = await open(requireString(parsed.input, 'open requires --input'), commonOptions);
+      outputResult(parsed.json, {
+        format: reader.format,
+        detection: reader.detection
+      });
+      return 0;
+    }
+    case 'detect': {
+      const result = await detect(requireString(parsed.input, 'detect requires --input'), commonOptions);
+      outputResult(parsed.json, result);
+      return 0;
+    }
+    case 'list': {
+      const result = await list(requireString(parsed.input, 'list requires --input'), commonOptions);
+      outputResult(parsed.json, result);
+      return 0;
+    }
+    case 'audit': {
+      const result = await audit(requireString(parsed.input, 'audit requires --input'), commonOptions);
+      outputResult(parsed.json, result);
+      return 0;
+    }
+    case 'extract': {
+      const result = await extract(
+        requireString(parsed.input, 'extract requires --input'),
+        requireString(parsed.output, 'extract requires --output'),
+        {
+          ...commonOptions,
+          allowSymlinks: parsed.allowSymlinks,
+          allowHardlinks: parsed.allowHardlinks,
+          ...(typeof parsed.maxEntryBytes === 'number' ? { maxEntryBytes: parsed.maxEntryBytes } : {}),
+          ...(typeof parsed.maxTotalExtractedBytes === 'number'
+            ? { maxTotalExtractedBytes: parsed.maxTotalExtractedBytes }
+            : {})
+        }
+      );
+      outputResult(parsed.json, result);
+      return 0;
+    }
+    case 'normalize': {
+      const result = await normalize(
+        requireString(parsed.input, 'normalize requires --input'),
+        requireString(parsed.output, 'normalize requires --output'),
+        {
+          ...commonOptions
+        }
+      );
+      outputResult(parsed.json, result);
+      return 0;
+    }
+    default:
+      break;
+  }
+
+  const unreachable: never = command;
+  throw new Error(`Unhandled command: ${String(unreachable)}`);
 };
 
-void run().catch( ( err: unknown ) => {
-	const normalizedError = err instanceof Error ? err : new Error( String( err ) );
-	console.error( normalizedError );
-	process.exitCode = 1;
-} );
+const outputResult = (asJson: boolean, payload: unknown): void => {
+  if (asJson) {
+    console.log(JSON.stringify(payload));
+    return;
+  }
+  console.log(payload);
+};
+
+const requireString = (value: string | undefined, message: string): string => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new DirArchiverError('DIRARCHIVER_USAGE', message);
+  }
+  return value;
+};
+
+void run()
+  .then((exitCode) => {
+    process.exitCode = exitCode;
+  })
+  .catch((error: unknown) => {
+    if (error instanceof DirArchiverError) {
+      console.error(JSON.stringify(error.toJSON()));
+      process.exitCode = 1;
+      return;
+    }
+    if (error instanceof Error) {
+      console.error(error.stack ?? error.message);
+    } else {
+      console.error(String(error));
+    }
+    process.exitCode = 1;
+  });

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,718 @@
+import {
+  createReadStream,
+  createWriteStream,
+  existsSync,
+  promises as fsPromises,
+  statSync
+} from 'node:fs';
+import path from 'node:path';
+import { Readable, Writable } from 'node:stream';
+import type {
+  ArchiveAuditReport,
+  ArchiveFormat,
+  ArchiveIssue,
+  ArchiveOpenOptions,
+  ArchiveReader,
+  ArchiveWriter
+} from '@ismail-elkorchi/bytefold';
+import { DirArchiverError } from './errors.js';
+import { loadRuntimeBindings } from './runtime/index.js';
+import type {
+  DetectResult,
+  DirArchiverInput,
+  ExtractOptions,
+  ExtractResult,
+  ListEntry,
+  ListResult,
+  NormalizeOptions,
+  NormalizeResult,
+  OpenOptions,
+  WriteOptions,
+  WriteResult
+} from './types.js';
+
+const DIRECTORY_TO_SINGLE_FILE_CODEC = {
+  gz: 'tar.gz',
+  bz2: 'tar.bz2',
+  xz: 'tar.xz',
+  zst: 'tar.zst',
+  br: 'tar.br'
+} as const satisfies Partial<Record<ArchiveFormat, ArchiveFormat>>;
+
+const writeUnsupportedFormats = new Set<ArchiveFormat>(['tar.bz2', 'bz2', 'tar.xz', 'xz']);
+
+/**
+ * Opens an archive input with bytefold runtime bindings.
+ */
+export const open = async (input: DirArchiverInput, options: OpenOptions = {}): Promise<ArchiveReader> => {
+  const runtime = await loadRuntimeBindings();
+  return runtime.openArchive(input, toArchiveOpenOptions(options));
+};
+
+/**
+ * Detects archive format and exposes bytefold detection metadata.
+ */
+export const detect = async (input: DirArchiverInput, options: OpenOptions = {}): Promise<DetectResult> => {
+  const reader = await open(input, options);
+  try {
+    return {
+      format: reader.format,
+      detection: reader.detection
+    };
+  } finally {
+    await disposeArchiveReader(reader);
+  }
+};
+
+/**
+ * Lists archive entries without extracting to disk.
+ */
+export const list = async (input: DirArchiverInput, options: OpenOptions = {}): Promise<ListResult> => {
+  const reader = await open(input, options);
+  try {
+    const entries: ListEntry[] = [];
+    for await (const entry of reader.entries()) {
+      entries.push({
+        format: entry.format,
+        name: entry.name,
+        size: entry.size.toString(),
+        isDirectory: entry.isDirectory,
+        isSymlink: entry.isSymlink,
+        ...(typeof entry.linkName === 'string' ? { linkName: entry.linkName } : {})
+      });
+    }
+    return {
+      format: reader.format,
+      detection: reader.detection,
+      entries
+    };
+  } finally {
+    await disposeArchiveReader(reader);
+  }
+};
+
+/**
+ * Runs bytefold audit checks for the selected safety profile.
+ */
+export const audit = async (
+  input: DirArchiverInput,
+  options: OpenOptions = {}
+): Promise<ArchiveAuditReport> => {
+  const reader = await open(input, options);
+  try {
+    return await reader.audit(toAuditOptions(options));
+  } finally {
+    await disposeArchiveReader(reader);
+  }
+};
+
+/**
+ * Writes a normalized deterministic archive when supported by the format.
+ */
+export const normalize = async (
+  input: DirArchiverInput,
+  destination: string,
+  options: NormalizeOptions = {}
+): Promise<NormalizeResult> => {
+  const reader = await open(input, options);
+  try {
+    if (typeof reader.normalizeToWritable !== 'function') {
+      throw new DirArchiverError(
+        'DIRARCHIVER_NORMALIZE_UNSUPPORTED',
+        `Normalize is unavailable for format "${reader.format}".`
+      );
+    }
+
+    const destinationPath = path.resolve(destination);
+    await ensureParentDirectory(destinationPath);
+    const writable = createFileWritable(destinationPath);
+    const report = await reader.normalizeToWritable(
+      writable,
+      toNormalizeOptions(options)
+    );
+    return {
+      format: reader.format,
+      report
+    };
+  } finally {
+    await disposeArchiveReader(reader);
+  }
+};
+
+/**
+ * Extracts entries to a destination directory with safety enforcement.
+ */
+export const extract = async (
+  input: DirArchiverInput,
+  destination: string,
+  options: ExtractOptions = {}
+): Promise<ExtractResult> => {
+  const reader = await open(input, options);
+  try {
+    const profile = options.profile ?? 'strict';
+    const issues: ArchiveIssue[] = [];
+    const destinationRoot = path.resolve(destination);
+
+    await fsPromises.mkdir(destinationRoot, { recursive: true });
+
+    if (profile !== 'compat') {
+      if (profile === 'agent') {
+        try {
+          await reader.assertSafe(toAuditOptions({
+            ...options,
+            profile
+          }));
+        } catch (error) {
+          throw new DirArchiverError(
+            'DIRARCHIVER_UNSUPPORTED_ENTRY',
+            'Archive assertSafe failed under agent safety profile.',
+            { cause: error }
+          );
+        }
+      }
+
+      const auditReport = await reader.audit(
+        toAuditOptions({
+          ...options,
+          profile
+        })
+      );
+      if (!auditReport.ok) {
+        const hasTraversalIssue = auditReport.issues.some((issue) =>
+          issue.code.includes('TRAVERSAL')
+          || issue.code.includes('ABSOLUTE')
+        );
+        throw new DirArchiverError(
+          hasTraversalIssue ? 'DIRARCHIVER_PATH_TRAVERSAL' : 'DIRARCHIVER_UNSUPPORTED_ENTRY',
+          'Archive audit failed under strict safety profile.',
+          {
+            context: {
+              issues: auditReport.issues
+            }
+          }
+        );
+      }
+      issues.push(...auditReport.issues);
+    }
+
+    let extractedFiles = 0;
+    let extractedDirectories = 0;
+    let skippedEntries = 0;
+    let totalExtractedBytes = 0;
+
+    for await (const entry of reader.entries()) {
+      const destinationPath = resolveEntryDestination(destinationRoot, entry.name);
+
+      if (entry.isDirectory) {
+        await fsPromises.mkdir(destinationPath, { recursive: true });
+        extractedDirectories += 1;
+        continue;
+      }
+
+      if (entry.isSymlink) {
+        if (options.allowSymlinks !== true) {
+          skippedEntries += 1;
+          continue;
+        }
+        if (typeof entry.linkName !== 'string' || entry.linkName.length === 0) {
+          throw new DirArchiverError(
+            'DIRARCHIVER_UNSUPPORTED_ENTRY',
+            `Symlink "${entry.name}" is missing a link target.`
+          );
+        }
+        const symlinkTarget = normalizeSymlinkTarget(entry.linkName);
+        await ensureParentDirectory(destinationPath);
+        await fsPromises.symlink(symlinkTarget, destinationPath);
+        continue;
+      }
+
+      if (typeof entry.linkName === 'string' && entry.linkName.length > 0) {
+        throw new DirArchiverError(
+          'DIRARCHIVER_UNSUPPORTED_ENTRY',
+          `Hard link entry "${entry.name}" is not supported by dir-archiver v3.`
+        );
+      }
+
+      const stream = await entry.open();
+      const bytes = await readAllBytes(stream, options.maxEntryBytes, options.maxTotalExtractedBytes, totalExtractedBytes);
+      totalExtractedBytes += bytes.length;
+
+      await ensureParentDirectory(destinationPath);
+      await fsPromises.writeFile(destinationPath, bytes);
+      extractedFiles += 1;
+    }
+
+    return {
+      format: reader.format,
+      destination: destinationRoot,
+      extractedFiles,
+      extractedDirectories,
+      skippedEntries,
+      issues
+    };
+  } finally {
+    await disposeArchiveReader(reader);
+  }
+};
+
+/**
+ * Writes an archive from a file or directory source.
+ */
+export const write = async (
+  source: string,
+  destination: string,
+  options: WriteOptions = {}
+): Promise<WriteResult> => {
+  const runtime = await loadRuntimeBindings();
+  const sourcePath = path.resolve(source);
+  const destinationPath = path.resolve(destination);
+  const requestedFormat = options.format ?? inferFormatFromDestination(destinationPath) ?? 'zip';
+  const sourceStats = await fsPromises.lstat(sourcePath);
+  const sourceIsDirectory = sourceStats.isDirectory();
+  const wrappedFormat = sourceIsDirectory
+    ? DIRECTORY_TO_SINGLE_FILE_CODEC[requestedFormat as keyof typeof DIRECTORY_TO_SINGLE_FILE_CODEC]
+    : undefined;
+  const wrappedDirectoryCodec = typeof wrappedFormat === 'string';
+  const outputFormat = wrappedFormat ?? requestedFormat;
+
+  if (writeUnsupportedFormats.has(outputFormat)) {
+    throw new DirArchiverError(
+      'DIRARCHIVER_UNSUPPORTED_ENTRY',
+      `Write format "${outputFormat}" is unsupported by bytefold writers.`
+    );
+  }
+
+  await ensureParentDirectory(destinationPath);
+
+  const writer = runtime.createArchiveWriter(
+    outputFormat,
+    createFileWritable(destinationPath)
+  ) as ArchiveWriter;
+
+  const entries = sourceIsDirectory
+    ? await collectDirectoryEntries(sourcePath, options)
+    : [{
+      sourcePath,
+      archivePath: path.basename(sourcePath).replace(/\\/g, '/')
+    }];
+
+  for (const entry of entries) {
+    const bytes = await fsPromises.readFile(entry.sourcePath);
+    await writer.add(entry.archivePath, bytes);
+  }
+  await writer.close();
+
+  return {
+    format: outputFormat,
+    source: sourcePath,
+    destination: destinationPath,
+    entryCount: entries.length,
+    wrappedDirectoryCodec
+  };
+};
+
+interface PendingEntry {
+  sourcePath: string;
+  archivePath: string;
+}
+
+interface ExcludeMatcher {
+  isExcluded: (relativePath: string) => boolean;
+}
+
+const collectDirectoryEntries = async (
+  sourcePath: string,
+  options: WriteOptions
+): Promise<PendingEntry[]> => {
+  const includeBaseDirectory = options.includeBaseDirectory === true;
+  const followSymlinks = options.followSymlinks === true;
+  const sourceBaseName = path.basename(sourcePath);
+  const excludeMatcher = createExcludeMatcher(sourcePath, options.exclude ?? []);
+  const visitedDirectories = new Set<string>();
+  const toVisit: string[] = [sourcePath];
+  const files: PendingEntry[] = [];
+
+  while (toVisit.length > 0) {
+    const nextDirectory = toVisit.pop();
+    if (!nextDirectory) {
+      continue;
+    }
+
+    if (followSymlinks) {
+      const real = await fsPromises.realpath(nextDirectory).catch(() => null);
+      if (!real || visitedDirectories.has(real)) {
+        continue;
+      }
+      visitedDirectories.add(real);
+    }
+
+    const directoryEntries = await fsPromises.readdir(nextDirectory, { withFileTypes: true });
+    directoryEntries.sort((left, right) => left.name.localeCompare(right.name));
+
+    for (const entry of directoryEntries) {
+      const sourceEntryPath = path.join(nextDirectory, entry.name);
+      const relativePath = path.relative(sourcePath, sourceEntryPath);
+
+      if (excludeMatcher.isExcluded(relativePath)) {
+        continue;
+      }
+
+      if (entry.isDirectory()) {
+        toVisit.push(sourceEntryPath);
+        continue;
+      }
+
+      if (entry.isFile()) {
+        files.push({
+          sourcePath: sourceEntryPath,
+          archivePath: toArchivePath(relativePath, includeBaseDirectory ? sourceBaseName : undefined)
+        });
+        continue;
+      }
+
+      if (!entry.isSymbolicLink() || !followSymlinks) {
+        continue;
+      }
+
+      const stats = await fsPromises.stat(sourceEntryPath).catch(() => null);
+      if (!stats) {
+        continue;
+      }
+      if (stats.isDirectory()) {
+        toVisit.push(sourceEntryPath);
+      } else if (stats.isFile()) {
+        files.push({
+          sourcePath: sourceEntryPath,
+          archivePath: toArchivePath(relativePath, includeBaseDirectory ? sourceBaseName : undefined)
+        });
+      }
+    }
+  }
+
+  files.sort((left, right) => left.archivePath.localeCompare(right.archivePath));
+  return files;
+};
+
+const toArchiveOpenOptions = (options: OpenOptions): ArchiveOpenOptions => {
+  const archiveOptions: ArchiveOpenOptions = {};
+  if (options.format !== undefined) {
+    archiveOptions.format = options.format;
+  }
+  if (options.profile !== undefined) {
+    archiveOptions.profile = options.profile;
+  }
+  if (options.isStrict !== undefined) {
+    archiveOptions.isStrict = options.isStrict;
+  }
+  if (options.limits !== undefined) {
+    archiveOptions.limits = options.limits;
+  }
+  if (options.signal !== undefined) {
+    archiveOptions.signal = options.signal;
+  }
+  if (options.password !== undefined) {
+    archiveOptions.password = options.password;
+  }
+  if (options.filename !== undefined) {
+    archiveOptions.filename = options.filename;
+  }
+  return archiveOptions;
+};
+
+const toAuditOptions = (
+  options: OpenOptions
+): Parameters<ArchiveReader['audit']>[0] => {
+  const auditOptions: {
+    profile?: OpenOptions['profile'];
+    isStrict?: OpenOptions['isStrict'];
+    limits?: OpenOptions['limits'];
+    signal?: OpenOptions['signal'];
+  } = {};
+  if (options.profile !== undefined) {
+    auditOptions.profile = options.profile;
+  }
+  if (options.isStrict !== undefined) {
+    auditOptions.isStrict = options.isStrict;
+  }
+  if (options.limits !== undefined) {
+    auditOptions.limits = options.limits;
+  }
+  if (options.signal !== undefined) {
+    auditOptions.signal = options.signal;
+  }
+  return auditOptions as Parameters<ArchiveReader['audit']>[0];
+};
+
+const toNormalizeOptions = (
+  options: NormalizeOptions
+): Parameters<NonNullable<ArchiveReader['normalizeToWritable']>>[1] => {
+  const normalizeOptions: {
+    isDeterministic: boolean;
+    limits?: NormalizeOptions['limits'];
+    signal?: NormalizeOptions['signal'];
+  } = {
+    isDeterministic: options.deterministic ?? true
+  };
+  if (options.limits !== undefined) {
+    normalizeOptions.limits = options.limits;
+  }
+  if (options.signal !== undefined) {
+    normalizeOptions.signal = options.signal;
+  }
+  return normalizeOptions as Parameters<NonNullable<ArchiveReader['normalizeToWritable']>>[1];
+};
+
+const createExcludeMatcher = (sourcePath: string, excludes: string[]): ExcludeMatcher => {
+  const excludedPaths = new Set<string>();
+  const excludedNames = new Set<string>();
+  const caseInsensitive = process.platform === 'win32';
+
+  for (const rawExclude of excludes) {
+    const normalizedExclude = normalizeExcludeInput(rawExclude, sourcePath);
+    if (!normalizedExclude) {
+      continue;
+    }
+    const hasSeparator = normalizedExclude.includes('/') || normalizedExclude.includes('\\') || normalizedExclude.includes(path.sep);
+    const normalizedValue = normalizeCase(normalizedExclude, caseInsensitive);
+    excludedPaths.add(normalizedValue);
+    if (!hasSeparator) {
+      excludedNames.add(normalizedValue);
+    }
+  }
+
+  return {
+    isExcluded(relativePath: string): boolean {
+      const normalizedRelativePath = normalizeCase(path.normalize(relativePath), caseInsensitive);
+      if (excludedPaths.has(normalizedRelativePath)) {
+        return true;
+      }
+      const baseName = normalizeCase(path.basename(normalizedRelativePath), caseInsensitive);
+      return excludedNames.has(baseName);
+    }
+  };
+};
+
+const normalizeExcludeInput = (excludeRaw: string, sourcePath: string): string | undefined => {
+  if (typeof excludeRaw !== 'string') {
+    return undefined;
+  }
+  const trimmed = excludeRaw.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  let normalized = path.normalize(trimmed.replace(/\\/g, path.sep));
+  if (normalized === '.' || normalized === path.sep) {
+    return undefined;
+  }
+
+  if (path.isAbsolute(normalized)) {
+    const relativeCandidate = path.relative(sourcePath, normalized);
+    const isInsideSource = relativeCandidate.length > 0
+      && !relativeCandidate.startsWith('..')
+      && !path.isAbsolute(relativeCandidate);
+    if (isInsideSource) {
+      normalized = path.normalize(relativeCandidate);
+    }
+  }
+
+  normalized = trimTrailingPathSeparators(normalized);
+  if (normalized.length === 0 || normalized === '.') {
+    return undefined;
+  }
+  return normalized;
+};
+
+const normalizeCase = (value: string, caseInsensitive: boolean): string => {
+  return caseInsensitive ? value.toLowerCase() : value;
+};
+
+const trimTrailingPathSeparators = (value: string): string => {
+  let end = value.length;
+  while (end > 0) {
+    const code = value.charCodeAt(end - 1);
+    if (code === 47 || code === 92) {
+      end -= 1;
+      continue;
+    }
+    break;
+  }
+  return value.slice(0, end);
+};
+
+const toArchivePath = (relativePath: string, baseDirectory?: string): string => {
+  const normalized = relativePath.replace(/\\/g, '/');
+  if (baseDirectory) {
+    return path.posix.join(baseDirectory, normalized);
+  }
+  return normalized;
+};
+
+const normalizeArchiveEntryName = (entryName: string): string => {
+  const normalizedSlashes = entryName.replace(/\\/g, '/');
+  if (normalizedSlashes.length === 0) {
+    throw new DirArchiverError('DIRARCHIVER_PATH_TRAVERSAL', 'Archive entry name is empty.');
+  }
+  if (normalizedSlashes.startsWith('/') || /^[a-zA-Z]:\//u.test(normalizedSlashes)) {
+    throw new DirArchiverError(
+      'DIRARCHIVER_PATH_TRAVERSAL',
+      `Archive entry "${entryName}" is absolute and cannot be extracted safely.`
+    );
+  }
+  const parts = normalizedSlashes.split('/').filter((part) => part.length > 0 && part !== '.');
+  if (parts.some((part) => part === '..')) {
+    throw new DirArchiverError(
+      'DIRARCHIVER_PATH_TRAVERSAL',
+      `Archive entry "${entryName}" escapes extraction root.`
+    );
+  }
+  return parts.join('/');
+};
+
+const resolveEntryDestination = (destinationRoot: string, entryName: string): string => {
+  const safeRelative = normalizeArchiveEntryName(entryName);
+  const resolved = path.resolve(destinationRoot, safeRelative);
+  if (resolved !== destinationRoot && !resolved.startsWith(`${destinationRoot}${path.sep}`)) {
+    throw new DirArchiverError(
+      'DIRARCHIVER_PATH_TRAVERSAL',
+      `Archive entry "${entryName}" resolves outside destination root.`
+    );
+  }
+  return resolved;
+};
+
+const normalizeSymlinkTarget = (linkName: string): string => {
+  const normalized = linkName.replace(/\\/g, '/');
+  if (normalized.startsWith('/') || /^[a-zA-Z]:\//u.test(normalized)) {
+    throw new DirArchiverError(
+      'DIRARCHIVER_PATH_TRAVERSAL',
+      `Symlink target "${linkName}" is absolute and not allowed.`
+    );
+  }
+  const parts = normalized.split('/').filter((part) => part.length > 0 && part !== '.');
+  if (parts.some((part) => part === '..')) {
+    throw new DirArchiverError(
+      'DIRARCHIVER_PATH_TRAVERSAL',
+      `Symlink target "${linkName}" escapes extraction root.`
+    );
+  }
+  return parts.join('/');
+};
+
+const readAllBytes = async (
+  stream: ReadableStream<Uint8Array>,
+  maxEntryBytes?: number,
+  maxTotalBytes?: number,
+  currentTotalBytes = 0
+): Promise<Uint8Array> => {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let entryTotal = 0;
+
+  try {
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) {
+        break;
+      }
+      if (!(chunk.value instanceof Uint8Array)) {
+        continue;
+      }
+      entryTotal += chunk.value.length;
+      if (typeof maxEntryBytes === 'number' && entryTotal > maxEntryBytes) {
+        throw new DirArchiverError(
+          'DIRARCHIVER_RESOURCE_LIMIT',
+          `Entry exceeds maxEntryBytes (${maxEntryBytes}).`,
+          {
+            context: {
+              maxEntryBytes,
+              actualEntryBytes: entryTotal
+            }
+          }
+        );
+      }
+      const projectedTotal = currentTotalBytes + entryTotal;
+      if (typeof maxTotalBytes === 'number' && projectedTotal > maxTotalBytes) {
+        throw new DirArchiverError(
+          'DIRARCHIVER_RESOURCE_LIMIT',
+          `Extraction exceeds maxTotalExtractedBytes (${maxTotalBytes}).`,
+          {
+            context: {
+              maxTotalExtractedBytes: maxTotalBytes,
+              projectedTotalBytes: projectedTotal
+            }
+          }
+        );
+      }
+      chunks.push(chunk.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const output = new Uint8Array(entryTotal);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return output;
+};
+
+const ensureParentDirectory = async (targetPath: string): Promise<void> => {
+  await fsPromises.mkdir(path.dirname(targetPath), { recursive: true });
+};
+
+const createFileWritable = (targetPath: string): WritableStream<Uint8Array> => {
+  const writable = createWriteStream(targetPath);
+  return Writable.toWeb(writable) as WritableStream<Uint8Array>;
+};
+
+const inferFormatFromDestination = (destinationPath: string): ArchiveFormat | undefined => {
+  const lower = destinationPath.toLowerCase();
+  if (lower.endsWith('.tar.gz') || lower.endsWith('.tgz')) return 'tar.gz';
+  if (lower.endsWith('.tar.bz2')) return 'tar.bz2';
+  if (lower.endsWith('.tar.xz')) return 'tar.xz';
+  if (lower.endsWith('.tar.zst')) return 'tar.zst';
+  if (lower.endsWith('.tar.br')) return 'tar.br';
+  if (lower.endsWith('.tar')) return 'tar';
+  if (lower.endsWith('.zip')) return 'zip';
+  if (lower.endsWith('.gz')) return 'gz';
+  if (lower.endsWith('.bz2')) return 'bz2';
+  if (lower.endsWith('.xz')) return 'xz';
+  if (lower.endsWith('.zst')) return 'zst';
+  if (lower.endsWith('.br')) return 'br';
+  return undefined;
+};
+
+export const copyStreamToFile = async (source: string, destination: string): Promise<void> => {
+  await ensureParentDirectory(destination);
+  const nodeReadable = createReadStream(source);
+  const webReadable = Readable.toWeb(nodeReadable) as ReadableStream<Uint8Array>;
+  const bytes = await readAllBytes(webReadable);
+  await fsPromises.writeFile(destination, bytes);
+};
+
+export const pathExists = (value: string): boolean => existsSync(value);
+
+export const fileSize = (value: string): number => statSync(value).size;
+
+const disposeArchiveReader = async (reader: ArchiveReader): Promise<void> => {
+  const withAsyncDispose = reader as {
+    [Symbol.asyncDispose]?: () => Promise<void>;
+    dispose?: () => Promise<void>;
+    close?: () => Promise<void>;
+  };
+  const asyncDispose = withAsyncDispose[Symbol.asyncDispose];
+  if (typeof asyncDispose === 'function') {
+    await asyncDispose.call(withAsyncDispose);
+    return;
+  }
+  if (typeof withAsyncDispose.dispose === 'function') {
+    await withAsyncDispose.dispose();
+    return;
+  }
+  if (typeof withAsyncDispose.close === 'function') {
+    await withAsyncDispose.close();
+  }
+};

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,58 @@
+/**
+ * Stable dir-archiver error codes.
+ */
+export type DirArchiverErrorCode =
+  | 'DIRARCHIVER_INVALID_SOURCE'
+  | 'DIRARCHIVER_INVALID_DESTINATION'
+  | 'DIRARCHIVER_PATH_TRAVERSAL'
+  | 'DIRARCHIVER_UNSUPPORTED_ENTRY'
+  | 'DIRARCHIVER_RESOURCE_LIMIT'
+  | 'DIRARCHIVER_RUNTIME_UNSUPPORTED'
+  | 'DIRARCHIVER_NORMALIZE_UNSUPPORTED'
+  | 'DIRARCHIVER_USAGE';
+
+/**
+ * Structured error contract for dir-archiver v3.
+ */
+export class DirArchiverError extends Error {
+  readonly code: DirArchiverErrorCode;
+  readonly hint: string | undefined;
+  readonly context: Record<string, unknown> | undefined;
+
+  constructor(
+    code: DirArchiverErrorCode,
+    message: string,
+    options: {
+      hint?: string | undefined;
+      context?: Record<string, unknown> | undefined;
+      cause?: unknown;
+    } = {}
+  ) {
+    super(message);
+    this.name = 'DirArchiverError';
+    this.code = code;
+    this.hint = options.hint;
+    this.context = options.context;
+    if (options.cause !== undefined) {
+      (this as { cause?: unknown }).cause = options.cause;
+    }
+  }
+
+  toJSON(): {
+    schemaVersion: '1';
+    name: 'DirArchiverError';
+    code: DirArchiverErrorCode;
+    message: string;
+    hint?: string;
+    context?: Record<string, unknown>;
+  } {
+    return {
+      schemaVersion: '1',
+      name: 'DirArchiverError',
+      code: this.code,
+      message: this.message,
+      ...(this.hint ? { hint: this.hint } : {}),
+      ...(this.context ? { context: this.context } : {})
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,288 +1,48 @@
-'use strict';
+/**
+ * dir-archiver v3 API surface.
+ *
+ * v3 is a bytefold-backed orchestration layer that supports Node.js, Deno, and Bun.
+ */
+import { audit, detect, extract, list, normalize, open, write } from './core.js';
 
-import * as path from 'node:path';
-import * as fs from 'node:fs';
-import { loadRuntimeZipWriter } from './runtime/index.js';
-import type { ZipWriterLike } from './runtime/types.js';
-
-interface RuntimeProcessLike {
-	platform?: string;
-}
-
-interface DenoGlobalLike {
-	build?: {
-		os?: string;
-	};
-}
-
-interface BunGlobalLike {
-	platform?: string;
-}
-
-const getRuntimePlatform = (): string | undefined => {
-	const runtimeProcess = ( globalThis as { process?: RuntimeProcessLike } ).process;
-	if ( typeof runtimeProcess?.platform === 'string' ) {
-		return runtimeProcess.platform;
-	}
-	const denoGlobal = ( globalThis as { Deno?: DenoGlobalLike } ).Deno;
-	const denoPlatform = denoGlobal?.build?.os;
-	if ( denoPlatform === 'windows' ) {
-		return 'win32';
-	}
-	if ( typeof denoPlatform === 'string' ) {
-		return denoPlatform;
-	}
-	const bunGlobal = ( globalThis as { Bun?: BunGlobalLike } ).Bun;
-	if ( typeof bunGlobal?.platform === 'string' ) {
-		return bunGlobal.platform;
-	}
-	return undefined;
+export {
+  audit,
+  detect,
+  extract,
+  list,
+  normalize,
+  open,
+  write
 };
 
-interface ArchiveFileEntry {
-	sourcePath: string;
-	archivePath: string;
-}
+export { DirArchiverError } from './errors.js';
+export type {
+  ArchiveFormat,
+  ArchiveLimits,
+  ArchiveProfile,
+  CliUsageError,
+  DetectResult,
+  DirArchiverInput,
+  ExtractOptions,
+  ExtractResult,
+  ListEntry,
+  ListResult,
+  NormalizeOptions,
+  NormalizeResult,
+  OpenOptions,
+  SupportedCommandMap,
+  WriteOptions,
+  WriteResult
+} from './types.js';
 
-class DirArchiver {
-	private excludedPaths: Set<string>;
-	private excludedNames: Set<string>;
-	private caseInsensitiveExcludes: boolean;
-	private directoryPath: string;
-	private zipPath: string;
-	private includeBaseDirectory: boolean;
-	private followSymlinks: boolean;
-	private baseDirectory: string;
-	private visitedDirectories: Set<string>;
+const api = {
+  open,
+  detect,
+  list,
+  audit,
+  normalize,
+  extract,
+  write
+};
 
-	/**
-	 * The constructor.
-	 * @param directoryPath - the path of the folder to archive.
-	 * @param zipPath - The path of the zip file to create.
-	 * @param includeBaseDirectory - Includes a base directory at the root of the archive. For example, if the root folder of your project is named "your-project", setting includeBaseDirectory to true will create an archive that includes this base directory. If this option is set to false the archive created will unzip its content to the current directory.
-	 * @param excludes - The name of the files and foldes to exclude.
-	 */
-	constructor(
-		directoryPath: string,
-		zipPath: string,
-		includeBaseDirectory = false,
-		excludes: string[] = [],
-		followSymlinks = false
-	) {
-		this.directoryPath = path.resolve( directoryPath );
-		this.zipPath = path.resolve( zipPath );
-		this.includeBaseDirectory = includeBaseDirectory;
-		this.followSymlinks = followSymlinks;
-		this.baseDirectory = path.basename( this.directoryPath );
-		this.visitedDirectories = new Set();
-		this.caseInsensitiveExcludes = getRuntimePlatform() === 'win32';
-
-		// Contains the excluded files and folders.
-		this.excludedPaths = new Set();
-		this.excludedNames = new Set();
-		for ( const excludeRaw of excludes ) {
-			if ( typeof excludeRaw !== 'string' ) {
-				continue;
-			}
-			const trimmedRaw = excludeRaw.trim();
-			if ( trimmedRaw.length === 0 ) {
-				continue;
-			}
-			let normalizedExclude = path.normalize( trimmedRaw.replace( /\\/g, path.sep ) );
-			if ( normalizedExclude === '.' || normalizedExclude === path.sep ) {
-				continue;
-			}
-			if ( path.isAbsolute( normalizedExclude ) ) {
-				const relativeCandidate = path.relative( this.directoryPath, normalizedExclude );
-				const isInsideSource = relativeCandidate.length > 0
-					&& ! relativeCandidate.startsWith( '..' )
-					&& ! path.isAbsolute( relativeCandidate );
-				if ( isInsideSource ) {
-					normalizedExclude = path.normalize( relativeCandidate );
-				}
-			}
-			if ( normalizedExclude.length === 0 ) {
-				continue;
-			}
-			const hasSeparator = normalizedExclude.includes( '/' )
-				|| normalizedExclude.includes( '\\' )
-				|| normalizedExclude.includes( path.sep );
-			const trimmedExclude = normalizedExclude.replace( /[\\/]+$/g, '' );
-			if ( trimmedExclude.length === 0 || trimmedExclude === '.' ) {
-				continue;
-			}
-			const normalizedValue = this.normalizeExcludeValue( trimmedExclude );
-			this.excludedPaths.add( normalizedValue );
-			if ( ! hasSeparator ) {
-				this.excludedNames.add( normalizedValue );
-			}
-		}
-
-		const relativeZipPath = path.relative( this.directoryPath, this.zipPath );
-		const isZipInsideSource = relativeZipPath.length > 0
-			&& ! relativeZipPath.startsWith( '..' )
-			&& ! path.isAbsolute( relativeZipPath );
-		if ( isZipInsideSource ) {
-			const normalizedZipPath = path.normalize( relativeZipPath );
-			this.excludedPaths.add( this.normalizeExcludeValue( normalizedZipPath ) );
-		}
-	}
-
-	/**
-	 * Recursively traverse the directory tree and collect files to append to the archive.
-	 * @param directoryPath - The path of the directory being looped through.
-	 */
-	private collectArchiveEntries( directoryPath: string ): ArchiveFileEntry[] {
-		const directoriesToVisit: string[] = [ directoryPath ];
-		const filesToArchive: ArchiveFileEntry[] = [];
-
-		while ( directoriesToVisit.length > 0 ) {
-			const nextDirectory = directoriesToVisit.pop();
-			if ( ! nextDirectory ) {
-				continue;
-			}
-
-			if ( this.followSymlinks ) {
-				try {
-					const realPath = fs.realpathSync( nextDirectory );
-					if ( this.visitedDirectories.has( realPath ) ) {
-						continue;
-					}
-					this.visitedDirectories.add( realPath );
-				} catch {
-					continue;
-				}
-			}
-
-			const resolvedDirectoryPath = path.resolve( nextDirectory );
-			const entries = fs.readdirSync( resolvedDirectoryPath, { withFileTypes: true } );
-			entries.sort( ( firstEntry, secondEntry ) => {
-				if ( firstEntry.name < secondEntry.name ) {
-					return -1;
-				}
-				if ( firstEntry.name > secondEntry.name ) {
-					return 1;
-				}
-				return 0;
-			} );
-			for ( const entry of entries ) {
-				const currentPath = path.join( resolvedDirectoryPath, entry.name );
-				if ( currentPath === this.zipPath ) {
-					continue;
-				}
-				const relativePath = path.relative( this.directoryPath, currentPath );
-				const normalizedRelativePath = path.normalize( relativePath );
-				const archiveRelativePath = normalizedRelativePath.replace( /\\/g, '/' );
-				const baseName = path.basename( normalizedRelativePath );
-				const normalizedPathValue = this.normalizeExcludeValue( normalizedRelativePath );
-				const normalizedNameValue = this.normalizeExcludeValue( baseName );
-				if ( this.excludedPaths.has( normalizedPathValue ) || this.excludedNames.has( normalizedNameValue ) ) {
-					continue;
-				}
-				if ( entry.isFile() ) {
-					filesToArchive.push( {
-						sourcePath: currentPath,
-						archivePath: this.getArchivePath( archiveRelativePath )
-					} );
-				} else if ( entry.isDirectory() ) {
-					directoriesToVisit.push( currentPath );
-				} else if ( entry.isSymbolicLink() ) {
-					if ( ! this.followSymlinks ) {
-						continue;
-					}
-					let stats: fs.Stats;
-					try {
-						stats = fs.statSync( currentPath );
-					} catch {
-						continue;
-					}
-					if ( stats.isFile() ) {
-						filesToArchive.push( {
-							sourcePath: currentPath,
-							archivePath: this.getArchivePath( archiveRelativePath )
-						} );
-					} else if ( stats.isDirectory() ) {
-						directoriesToVisit.push( currentPath );
-					}
-				}
-			}
-		}
-		return filesToArchive;
-	}
-
-	private prettyBytes( bytes: number ): string {
-		if ( bytes > 1000 && bytes < 1000000 ) {
-			const kiloBytes = Math.round( ( ( bytes / 1000 ) + Number.EPSILON ) * 100 ) / 100;
-			return `${kiloBytes} KB`;
-		}
-		if ( bytes > 1000000 && bytes < 1000000000 ) {
-			const megaBytes = Math.round( ( ( bytes / 1000000 ) + Number.EPSILON ) * 100 ) / 100;
-			return `${megaBytes} MB`;
-		}
-		if ( bytes > 1000000000 ) {
-			const gigaBytes = Math.round( ( ( bytes / 1000000000 ) + Number.EPSILON ) * 100 ) / 100;
-			return `${gigaBytes} GB`;
-		}
-		return `${bytes} bytes`;
-	}
-
-	private normalizeExcludeValue( value: string ): string {
-		return this.caseInsensitiveExcludes ? value.toLowerCase() : value;
-	}
-
-	private getArchivePath( archiveRelativePath: string ): string {
-		if ( this.includeBaseDirectory ) {
-			return path.posix.join( this.baseDirectory, archiveRelativePath );
-		}
-		return archiveRelativePath;
-	}
-
-	async createZip(): Promise<string> {
-		// Remove the destination zip if it exists.
-		// see : https://github.com/Ismail-elkorchi/dir-archiver/issues/5
-		if ( fs.existsSync( this.zipPath ) ) {
-			fs.unlinkSync( this.zipPath );
-		}
-		fs.accessSync( path.dirname( this.zipPath ), fs.constants.W_OK );
-		this.visitedDirectories.clear();
-		const filesToArchive = this.collectArchiveEntries( this.directoryPath );
-
-		const createZipWriter = await loadRuntimeZipWriter();
-		let writer: ZipWriterLike | undefined;
-
-		try {
-			writer = await createZipWriter( this.zipPath, {
-				// Keep deterministic entry ordering across platforms.
-				sinkSeekabilityPolicy: 'on'
-			} );
-
-			for ( const entry of filesToArchive ) {
-				await writer.add( entry.archivePath, entry.sourcePath );
-			}
-			await writer.close();
-		} catch ( err ) {
-			try {
-				if ( writer ) {
-					await writer.close();
-				}
-			} catch {
-				// Ignore close errors after archive failures.
-			}
-			try {
-				if ( fs.existsSync( this.zipPath ) ) {
-					fs.unlinkSync( this.zipPath );
-				}
-			} catch {
-				// Ignore cleanup errors.
-			}
-			const normalizedError = err instanceof Error ? err : new Error( String( err ) );
-			throw normalizedError;
-		}
-
-		const zipSize = fs.statSync( this.zipPath ).size;
-		console.log( `Created ${this.zipPath} of ${this.prettyBytes( zipSize )}` );
-		return this.zipPath;
-	}
-}
-
-export default DirArchiver;
+export default api;

--- a/src/runtime/bun.ts
+++ b/src/runtime/bun.ts
@@ -1,68 +1,25 @@
-import type { CreateZipWriter, ZipWriterLike, ZipWriterOptions } from './types.js';
+import type { RuntimeBindings } from './types.js';
 
-interface BunZipWriterLike {
-	add: (
-		name: string,
-		source: Uint8Array | ArrayBuffer | ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>
-	) => Promise<void>;
-	close: () => Promise<void>;
+interface BunRuntimeModule {
+  openArchive?: RuntimeBindings['openArchive'];
+  createArchiveWriter?: RuntimeBindings['createArchiveWriter'];
 }
 
-interface BunZipWriterModule {
-	zipToFile?: (
-		path: string | URL,
-		options?: ZipWriterOptions
-	) => Promise<BunZipWriterLike>;
-}
+let bunBindingsPromise: Promise<RuntimeBindings> | undefined;
 
-interface BunFileLike {
-	arrayBuffer: () => Promise<ArrayBuffer>;
-}
-
-interface BunGlobalLike {
-	file?: ( path: string | URL ) => BunFileLike;
-}
-
-let bunZipWriterPromise: Promise<CreateZipWriter> | undefined;
-
-const normalizeWriterOptions = ( options?: ZipWriterOptions ): ZipWriterOptions | undefined => {
-	if ( options?.sinkSeekabilityPolicy === 'on' ) {
-		return {
-			...options,
-			sinkSeekabilityPolicy: 'auto'
-		};
-	}
-	return options;
-};
-
-const readSourceAsUint8Array = async ( sourcePath: string ): Promise<Uint8Array> => {
-	const bunGlobal = ( globalThis as { Bun?: BunGlobalLike } ).Bun;
-	if ( typeof bunGlobal?.file !== 'function' ) {
-		throw new Error( 'Bun file API is unavailable.' );
-	}
-	const sourceFile = bunGlobal.file( sourcePath );
-	const sourceBytes = await sourceFile.arrayBuffer();
-	return new Uint8Array( sourceBytes );
-};
-
-export const loadBunZipWriter = async (): Promise<CreateZipWriter> => {
-	bunZipWriterPromise ??= import( '@ismail-elkorchi/bytefold/bun' )
-		.then( ( moduleExports ) => {
-			const zipToFile = ( moduleExports as BunZipWriterModule ).zipToFile;
-			if ( typeof zipToFile !== 'function' ) {
-				throw new Error( 'Bytefold bun zipToFile is unavailable.' );
-			}
-			return async ( filePath, options ) => {
-				const writer = await zipToFile( filePath, normalizeWriterOptions( options ) );
-				const wrappedWriter: ZipWriterLike = {
-					add: async ( name, sourcePath ) => {
-						const bytes = await readSourceAsUint8Array( sourcePath );
-						await writer.add( name, bytes );
-					},
-					close: () => writer.close()
-				};
-				return wrappedWriter;
-			};
-		} );
-	return bunZipWriterPromise;
+export const loadBunBindings = async (): Promise<RuntimeBindings> => {
+  bunBindingsPromise ??= import('@ismail-elkorchi/bytefold/bun')
+    .then((moduleExports) => {
+      const openArchive = (moduleExports as BunRuntimeModule).openArchive;
+      const createArchiveWriter = (moduleExports as BunRuntimeModule).createArchiveWriter;
+      if (typeof openArchive !== 'function' || typeof createArchiveWriter !== 'function') {
+        throw new Error('Bytefold bun runtime exports are unavailable.');
+      }
+      return {
+        runtime: 'bun',
+        openArchive,
+        createArchiveWriter
+      } satisfies RuntimeBindings;
+    });
+  return bunBindingsPromise;
 };

--- a/src/runtime/deno.ts
+++ b/src/runtime/deno.ts
@@ -1,63 +1,25 @@
-import type { CreateZipWriter, ZipWriterLike, ZipWriterOptions } from './types.js';
+import type { RuntimeBindings } from './types.js';
 
-interface DenoZipWriterLike {
-	add: (
-		name: string,
-		source: Uint8Array | ArrayBuffer | ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>
-	) => Promise<void>;
-	close: () => Promise<void>;
+interface DenoRuntimeModule {
+  openArchive?: RuntimeBindings['openArchive'];
+  createArchiveWriter?: RuntimeBindings['createArchiveWriter'];
 }
 
-interface DenoZipWriterModule {
-	zipToFile?: (
-		path: string | URL,
-		options?: ZipWriterOptions
-	) => Promise<DenoZipWriterLike>;
-}
+let denoBindingsPromise: Promise<RuntimeBindings> | undefined;
 
-interface DenoGlobalLike {
-	readFile?: ( path: string | URL ) => Promise<Uint8Array>;
-}
-
-let denoZipWriterPromise: Promise<CreateZipWriter> | undefined;
-
-const normalizeWriterOptions = ( options?: ZipWriterOptions ): ZipWriterOptions | undefined => {
-	if ( options?.sinkSeekabilityPolicy === 'on' ) {
-		return {
-			...options,
-			sinkSeekabilityPolicy: 'auto'
-		};
-	}
-	return options;
-};
-
-const getDenoReadFile = (): ( ( path: string | URL ) => Promise<Uint8Array> ) => {
-	const denoGlobal = ( globalThis as { Deno?: DenoGlobalLike } ).Deno;
-	if ( typeof denoGlobal?.readFile !== 'function' ) {
-		throw new Error( 'Deno readFile is unavailable.' );
-	}
-	return denoGlobal.readFile.bind( denoGlobal );
-};
-
-export const loadDenoZipWriter = async (): Promise<CreateZipWriter> => {
-	denoZipWriterPromise ??= import( '@ismail-elkorchi/bytefold/deno' )
-		.then( ( moduleExports ) => {
-			const zipToFile = ( moduleExports as DenoZipWriterModule ).zipToFile;
-			if ( typeof zipToFile !== 'function' ) {
-				throw new Error( 'Bytefold deno zipToFile is unavailable.' );
-			}
-			return async ( filePath, options ) => {
-				const readFile = getDenoReadFile();
-				const writer = await zipToFile( filePath, normalizeWriterOptions( options ) );
-				const wrappedWriter: ZipWriterLike = {
-					add: async ( name, sourcePath ) => {
-						const bytes = await readFile( sourcePath );
-						await writer.add( name, bytes );
-					},
-					close: () => writer.close()
-				};
-				return wrappedWriter;
-			};
-		} );
-	return denoZipWriterPromise;
+export const loadDenoBindings = async (): Promise<RuntimeBindings> => {
+  denoBindingsPromise ??= import('@ismail-elkorchi/bytefold/deno')
+    .then((moduleExports) => {
+      const openArchive = (moduleExports as DenoRuntimeModule).openArchive;
+      const createArchiveWriter = (moduleExports as DenoRuntimeModule).createArchiveWriter;
+      if (typeof openArchive !== 'function' || typeof createArchiveWriter !== 'function') {
+        throw new Error('Bytefold deno runtime exports are unavailable.');
+      }
+      return {
+        runtime: 'deno',
+        openArchive,
+        createArchiveWriter
+      } satisfies RuntimeBindings;
+    });
+  return denoBindingsPromise;
 };

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,50 +1,62 @@
-import { loadBunZipWriter } from './bun.js';
-import { loadDenoZipWriter } from './deno.js';
-import { loadNodeZipWriter } from './node.js';
-import type { CreateZipWriter } from './types.js';
-
-type RuntimeKind = 'node' | 'deno' | 'bun';
+import { DirArchiverError } from '../errors.js';
+import { loadBunBindings } from './bun.js';
+import { loadDenoBindings } from './deno.js';
+import { loadNodeBindings } from './node.js';
+import type { RuntimeBindings, RuntimeKind } from './types.js';
 
 interface NodeProcessLike {
-	versions?: {
-		node?: string;
-	};
+  versions?: {
+    node?: string;
+  };
 }
 
-const hasDenoGlobal = (): boolean => typeof ( globalThis as { Deno?: unknown } ).Deno !== 'undefined';
+interface DenoGlobalLike {
+  version?: {
+    deno?: string;
+  };
+}
 
-const hasBunGlobal = (): boolean => typeof ( globalThis as { Bun?: unknown } ).Bun !== 'undefined';
+interface BunGlobalLike {
+  version?: string;
+}
 
-const hasNodeProcess = (): boolean => {
-	const runtimeProcess = ( globalThis as { process?: NodeProcessLike } ).process;
-	return typeof runtimeProcess?.versions?.node === 'string';
-};
+const hasDenoGlobal = (): boolean =>
+  typeof (globalThis as { Deno?: DenoGlobalLike }).Deno?.version?.deno === 'string';
+
+const hasBunGlobal = (): boolean =>
+  typeof (globalThis as { Bun?: BunGlobalLike }).Bun?.version === 'string';
+
+const hasNodeProcess = (): boolean =>
+  typeof (globalThis as { process?: NodeProcessLike }).process?.versions?.node === 'string';
 
 const detectRuntime = (): RuntimeKind => {
-	if ( hasDenoGlobal() ) {
-		return 'deno';
-	}
-	if ( hasBunGlobal() ) {
-		return 'bun';
-	}
-	if ( hasNodeProcess() ) {
-		return 'node';
-	}
-	throw new Error( 'Unsupported runtime. Expected Node.js, Deno, or Bun.' );
+  if (hasDenoGlobal()) {
+    return 'deno';
+  }
+  if (hasBunGlobal()) {
+    return 'bun';
+  }
+  if (hasNodeProcess()) {
+    return 'node';
+  }
+  throw new DirArchiverError(
+    'DIRARCHIVER_RUNTIME_UNSUPPORTED',
+    'Unsupported runtime. Expected Node.js, Deno, or Bun.'
+  );
 };
 
-let runtimeZipWriterPromise: Promise<CreateZipWriter> | undefined;
+let runtimeBindingsPromise: Promise<RuntimeBindings> | undefined;
 
-export const loadRuntimeZipWriter = async (): Promise<CreateZipWriter> => {
-	runtimeZipWriterPromise ??= ( async () => {
-		const runtime = detectRuntime();
-		if ( runtime === 'deno' ) {
-			return loadDenoZipWriter();
-		}
-		if ( runtime === 'bun' ) {
-			return loadBunZipWriter();
-		}
-		return loadNodeZipWriter();
-	} )();
-	return runtimeZipWriterPromise;
+export const loadRuntimeBindings = async (): Promise<RuntimeBindings> => {
+  runtimeBindingsPromise ??= (async () => {
+    const runtime = detectRuntime();
+    if (runtime === 'deno') {
+      return loadDenoBindings();
+    }
+    if (runtime === 'bun') {
+      return loadBunBindings();
+    }
+    return loadNodeBindings();
+  })();
+  return runtimeBindingsPromise;
 };

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -1,21 +1,25 @@
-import type { CreateZipWriter } from './types.js';
+import type { RuntimeBindings } from './types.js';
 
-interface NodeZipWriterModule {
-	ZipWriter?: {
-		toFile?: CreateZipWriter;
-	};
+interface NodeRuntimeModule {
+  openArchive?: RuntimeBindings['openArchive'];
+  createArchiveWriter?: RuntimeBindings['createArchiveWriter'];
 }
 
-let nodeZipWriterPromise: Promise<CreateZipWriter> | undefined;
+let nodeBindingsPromise: Promise<RuntimeBindings> | undefined;
 
-export const loadNodeZipWriter = async (): Promise<CreateZipWriter> => {
-	nodeZipWriterPromise ??= import( '@ismail-elkorchi/bytefold/node/zip' )
-		.then( ( moduleExports ) => {
-			const ZipWriter = ( moduleExports as NodeZipWriterModule ).ZipWriter;
-			if ( ! ZipWriter || typeof ZipWriter.toFile !== 'function' ) {
-				throw new Error( 'Bytefold node ZipWriter.toFile is unavailable.' );
-			}
-			return ZipWriter.toFile.bind( ZipWriter );
-		} );
-	return nodeZipWriterPromise;
+export const loadNodeBindings = async (): Promise<RuntimeBindings> => {
+  nodeBindingsPromise ??= import('@ismail-elkorchi/bytefold/node')
+    .then((moduleExports) => {
+      const openArchive = (moduleExports as NodeRuntimeModule).openArchive;
+      const createArchiveWriter = (moduleExports as NodeRuntimeModule).createArchiveWriter;
+      if (typeof openArchive !== 'function' || typeof createArchiveWriter !== 'function') {
+        throw new Error('Bytefold node runtime exports are unavailable.');
+      }
+      return {
+        runtime: 'node',
+        openArchive,
+        createArchiveWriter
+      } satisfies RuntimeBindings;
+    });
+  return nodeBindingsPromise;
 };

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,16 +1,21 @@
-export interface ZipWriterLike {
-	add: (
-		name: string,
-		source: string
-	) => Promise<void>;
-	close: () => Promise<void>;
+import type { ArchiveFormat, ArchiveOpenOptions, ArchiveReader } from '@ismail-elkorchi/bytefold';
+
+export type RuntimeKind = 'node' | 'deno' | 'bun';
+
+export interface ArchiveWriterLike {
+  add: (
+    name: string,
+    source: Uint8Array | ArrayBuffer | ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>
+  ) => Promise<void>;
+  close: () => Promise<void>;
 }
 
-export interface ZipWriterOptions {
-	sinkSeekabilityPolicy?: 'auto' | 'on' | 'off';
+export interface RuntimeBindings {
+  runtime: RuntimeKind;
+  openArchive: (input: unknown, options?: ArchiveOpenOptions) => Promise<ArchiveReader>;
+  createArchiveWriter: (
+    format: ArchiveFormat,
+    writable: WritableStream<Uint8Array>,
+    options?: unknown
+  ) => ArchiveWriterLike;
 }
-
-export type CreateZipWriter = (
-	path: string | URL,
-	options?: ZipWriterOptions
-) => Promise<ZipWriterLike>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,151 @@
+import type {
+  ArchiveDetectionReport,
+  ArchiveFormat,
+  ArchiveIssue,
+  ArchiveLimits,
+  ArchiveNormalizeReport,
+  ArchiveOpenOptions,
+  ArchiveProfile
+} from '@ismail-elkorchi/bytefold';
+
+export type { ArchiveFormat, ArchiveLimits, ArchiveProfile };
+
+/**
+ * Accepted input shapes for archive read operations.
+ */
+export type DirArchiverInput =
+  | string
+  | URL
+  | Uint8Array
+  | ArrayBuffer
+  | ReadableStream<Uint8Array>
+  | Blob;
+
+/**
+ * Common options forwarded to bytefold open operations.
+ */
+export interface OpenOptions
+{
+  format?: ArchiveOpenOptions['format'] | undefined;
+  profile?: ArchiveOpenOptions['profile'] | undefined;
+  isStrict?: ArchiveOpenOptions['isStrict'] | undefined;
+  limits?: ArchiveOpenOptions['limits'] | undefined;
+  signal?: ArchiveOpenOptions['signal'] | undefined;
+  password?: ArchiveOpenOptions['password'] | undefined;
+  filename?: ArchiveOpenOptions['filename'] | undefined;
+}
+
+/**
+ * Format detection result.
+ */
+export interface DetectResult {
+  format: ArchiveFormat;
+  detection: ArchiveDetectionReport | undefined;
+}
+
+/**
+ * Single archive entry projection used by list responses.
+ */
+export interface ListEntry {
+  format: ArchiveFormat;
+  name: string;
+  size: string;
+  isDirectory: boolean;
+  isSymlink: boolean;
+  linkName?: string | undefined;
+}
+
+/**
+ * Archive listing response payload.
+ */
+export interface ListResult {
+  format: ArchiveFormat;
+  detection: ArchiveDetectionReport | undefined;
+  entries: ListEntry[];
+}
+
+export type AuditOptions = OpenOptions;
+
+/**
+ * Normalize operation options.
+ */
+export interface NormalizeOptions extends OpenOptions {
+  deterministic?: boolean | undefined;
+}
+
+/**
+ * Normalize operation result payload.
+ */
+export interface NormalizeResult {
+  format: ArchiveFormat;
+  report: ArchiveNormalizeReport;
+}
+
+/**
+ * Extraction options with explicit safety limits.
+ */
+export interface ExtractOptions extends OpenOptions {
+  allowSymlinks?: boolean | undefined;
+  allowHardlinks?: boolean | undefined;
+  maxEntryBytes?: number | undefined;
+  maxTotalExtractedBytes?: number | undefined;
+}
+
+/**
+ * Extraction summary result.
+ */
+export interface ExtractResult {
+  format: ArchiveFormat;
+  destination: string;
+  extractedFiles: number;
+  extractedDirectories: number;
+  skippedEntries: number;
+  issues: ArchiveIssue[];
+}
+
+/**
+ * Archive writer options.
+ */
+export interface WriteOptions {
+  format?: ArchiveFormat | undefined;
+  includeBaseDirectory?: boolean | undefined;
+  followSymlinks?: boolean | undefined;
+  exclude?: string[] | undefined;
+  profile?: ArchiveProfile | undefined;
+  limits?: ArchiveLimits | undefined;
+}
+
+/**
+ * Archive writer result payload.
+ */
+export interface WriteResult {
+  format: ArchiveFormat;
+  source: string;
+  destination: string;
+  entryCount: number;
+  wrappedDirectoryCodec: boolean;
+}
+
+/**
+ * Usage-error shape emitted by CLI parsing.
+ */
+export interface CliUsageError {
+  message: string;
+  issues: readonly {
+    code: string;
+    message: string;
+  }[];
+}
+
+/**
+ * Canonical command identifiers supported by the CLI contract.
+ */
+export interface SupportedCommandMap {
+  open: 'open';
+  detect: 'detect';
+  list: 'list';
+  audit: 'audit';
+  extract: 'extract';
+  normalize: 'normalize';
+  write: 'write';
+}

--- a/test/api-snapshot.test.mjs
+++ b/test/api-snapshot.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const SNAPSHOT = new URL('./fixtures/api-surface.v3.json', import.meta.url);
+
+test('v3 export surface matches snapshot', async () => {
+  const expected = JSON.parse(await readFile(SNAPSHOT, 'utf8'));
+  const mod = await import('../dist/index.js');
+  const actual = Object.keys(mod).sort();
+  assert.deepEqual(actual, expected);
+});

--- a/test/bun-smoke.mjs
+++ b/test/bun-smoke.mjs
@@ -1,36 +1,59 @@
-import { join } from 'node:path';
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, statSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import DirArchiver from '../dist/index.js';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { runtimeSupport, supportMatrix } from '@ismail-elkorchi/bytefold/support';
+import { extract, list, write } from '../dist/index.js';
 
 const run = async () => {
-	const normalizedTmpRoot = mkdtempSync( join( tmpdir(), 'dir-archiver-bun-' ) );
+  const tmpRoot = mkdtempSync(join(tmpdir(), 'dir-archiver-bun-'));
 
-	try {
-		const src = join( normalizedTmpRoot, 'src' );
-		const nested = join( src, 'nested' );
-		const dest = join( normalizedTmpRoot, 'archive.zip' );
+  try {
+    const source = join(tmpRoot, 'source');
+    mkdirSync(source, { recursive: true });
+    writeFileSync(join(source, 'hello.txt'), 'hello');
+    const archive = join(tmpRoot, 'archive.zip');
+    const extractTarget = join(tmpRoot, 'extracted');
 
-		mkdirSync( nested, { recursive: true } );
-		writeFileSync( join( src, 'root.txt' ), 'root' );
-		writeFileSync( join( nested, 'nested.txt' ), 'nested' );
+    await write(source, archive, { format: 'zip' });
+    if (!existsSync(archive)) {
+      throw new Error('Bun smoke: archive was not created.');
+    }
 
-		const archive = new DirArchiver( src, dest, false, [] );
-		await archive.createZip();
+    const listed = await list(archive, {});
+    if (listed.entries.length === 0) {
+      throw new Error('Bun smoke: list returned no entries.');
+    }
 
-		if ( ! existsSync( dest ) ) {
-			throw new Error( 'Bun smoke: destination archive was not created.' );
-		}
-		const stats = statSync( dest );
-		if ( ! stats.isFile() || stats.size <= 0 ) {
-			throw new Error( 'Bun smoke: destination archive is invalid.' );
-		}
-	} finally {
-		rmSync( normalizedTmpRoot, { recursive: true, force: true } );
-	}
+    await extract(archive, extractTarget, { profile: 'strict' });
+    const extractedFile = join(extractTarget, 'hello.txt');
+    if (readFileSync(extractedFile, 'utf8') !== 'hello') {
+      throw new Error('Bun smoke: extracted file content mismatch.');
+    }
+
+    const bunSupport = runtimeSupport('bun');
+    const unsupportedWriteFormat = supportMatrix.formats.find((format) => bunSupport[format].write.state !== 'supported');
+    if (!unsupportedWriteFormat) {
+      throw new Error('Bun smoke: expected at least one unsupported write format.');
+    }
+
+    let unsupportedFailed = false;
+    try {
+      await write(source, join(tmpRoot, `unsupported.${unsupportedWriteFormat.replace('/', '.')}`), {
+        format: unsupportedWriteFormat
+      });
+    } catch {
+      unsupportedFailed = true;
+    }
+    if (!unsupportedFailed) {
+      throw new Error(`Bun smoke: unsupported write format "${unsupportedWriteFormat}" unexpectedly succeeded.`);
+    }
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
 };
 
-run().catch( ( err ) => {
-	console.error( err );
-	process.exitCode = 1;
-} );
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+const CLI_PATH = path.join(process.cwd(), 'dist', 'cli.js');
+
+const runCli = (args) => {
+  return spawnSync(process.execPath, [CLI_PATH, ...args], {
+    encoding: 'utf8'
+  });
+};
+
+const cleanup = (target) => {
+  rmSync(target, { recursive: true, force: true });
+};
+
+test('unknown flag returns usage exit code and UNKNOWN_FLAG issue', () => {
+  const result = runCli(['detect', '--input', 'archive.zip', '--unknown', '1', '--json']);
+  assert.equal(result.status, 2);
+  const payload = JSON.parse(result.stdout.trim());
+  const issueCodes = payload.issues.map((issue) => issue.code);
+  assert.equal(issueCodes.includes('UNKNOWN_FLAG'), true);
+});
+
+test('write and extract commands succeed in JSON mode', () => {
+  const tmpRoot = mkdtempSync(path.join(tmpdir(), 'dir-archiver-cli-v3-'));
+  try {
+    const source = path.join(tmpRoot, 'src');
+    mkdirSync(source, { recursive: true });
+    writeFileSync(path.join(source, 'hello.txt'), 'hello');
+
+    const archive = path.join(tmpRoot, 'archive.zip');
+    const writeResult = runCli(['write', '--source', source, '--output', archive, '--json']);
+    assert.equal(writeResult.status, 0);
+
+    const extracted = path.join(tmpRoot, 'out');
+    const extractResult = runCli([
+      'extract',
+      '--input',
+      archive,
+      '--output',
+      extracted,
+      '--profile',
+      'strict',
+      '--json'
+    ]);
+    assert.equal(extractResult.status, 0);
+
+    const extractedFile = path.join(extracted, 'hello.txt');
+    assert.equal(readFileSync(extractedFile, 'utf8'), 'hello');
+  } finally {
+    cleanup(tmpRoot);
+  }
+});

--- a/test/deno-smoke.mjs
+++ b/test/deno-smoke.mjs
@@ -1,36 +1,58 @@
 /* global Deno */
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { mkdirSync, writeFileSync, existsSync, rmSync, statSync } from 'node:fs';
-import DirArchiver from '../dist/index.js';
+import { runtimeSupport, supportMatrix } from '@ismail-elkorchi/bytefold/support';
+import { extract, list, write } from '../dist/index.js';
 
 const run = async () => {
-	const tmpRoot = await Deno.makeTempDir( { prefix: 'dir-archiver-deno-' } );
+  const tmpRoot = await Deno.makeTempDir({ prefix: 'dir-archiver-deno-' });
 
-	try {
-		const src = join( tmpRoot, 'src' );
-		const nested = join( src, 'nested' );
-		const dest = join( tmpRoot, 'archive.zip' );
+  try {
+    const source = join(tmpRoot, 'source');
+    mkdirSync(source, { recursive: true });
+    writeFileSync(join(source, 'hello.txt'), 'hello');
+    const archive = join(tmpRoot, 'archive.zip');
+    const extractTarget = join(tmpRoot, 'extracted');
 
-		mkdirSync( nested, { recursive: true } );
-		writeFileSync( join( src, 'root.txt' ), 'root' );
-		writeFileSync( join( nested, 'nested.txt' ), 'nested' );
+    await write(source, archive, { format: 'zip' });
+    if (!existsSync(archive)) {
+      throw new Error('Deno smoke: archive was not created.');
+    }
 
-		const archive = new DirArchiver( src, dest, false, [] );
-		await archive.createZip();
+    const listed = await list(archive, {});
+    if (listed.entries.length === 0) {
+      throw new Error('Deno smoke: list returned no entries.');
+    }
 
-		if ( ! existsSync( dest ) ) {
-			throw new Error( 'Deno smoke: destination archive was not created.' );
-		}
-		const stats = statSync( dest );
-		if ( ! stats.isFile() || stats.size <= 0 ) {
-			throw new Error( 'Deno smoke: destination archive is invalid.' );
-		}
-	} finally {
-		rmSync( tmpRoot, { recursive: true, force: true } );
-	}
+    await extract(archive, extractTarget, { profile: 'strict' });
+    const extractedFile = join(extractTarget, 'hello.txt');
+    if (readFileSync(extractedFile, 'utf8') !== 'hello') {
+      throw new Error('Deno smoke: extracted file content mismatch.');
+    }
+
+    const denoSupport = runtimeSupport('deno');
+    const unsupportedWriteFormat = supportMatrix.formats.find((format) => denoSupport[format].write.state !== 'supported');
+    if (!unsupportedWriteFormat) {
+      throw new Error('Deno smoke: expected at least one unsupported write format.');
+    }
+
+    let unsupportedFailed = false;
+    try {
+      await write(source, join(tmpRoot, `unsupported.${unsupportedWriteFormat.replace('/', '.')}`), {
+        format: unsupportedWriteFormat
+      });
+    } catch {
+      unsupportedFailed = true;
+    }
+    if (!unsupportedFailed) {
+      throw new Error(`Deno smoke: unsupported write format "${unsupportedWriteFormat}" unexpectedly succeeded.`);
+    }
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
 };
 
-run().catch( ( err ) => {
-	console.error( err );
-	Deno.exit( 1 );
-} );
+run().catch((error) => {
+  console.error(error);
+  Deno.exit(1);
+});

--- a/test/fixtures/api-surface.v3.json
+++ b/test/fixtures/api-surface.v3.json
@@ -1,0 +1,11 @@
+[
+  "DirArchiverError",
+  "audit",
+  "default",
+  "detect",
+  "extract",
+  "list",
+  "normalize",
+  "open",
+  "write"
+]

--- a/test/matrix-node.test.mjs
+++ b/test/matrix-node.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { runtimeSupport, supportMatrix } from '@ismail-elkorchi/bytefold/support';
+import { detect, list, write } from '../dist/index.js';
+import { DirArchiverError } from '../dist/errors.js';
+
+const cleanup = (target) => {
+  rmSync(target, { recursive: true, force: true });
+};
+
+test('node matrix covers support-derived write/read scenarios', async () => {
+  const nodeSupport = runtimeSupport('node');
+  const candidateFormats = supportMatrix.formats.filter((format) => {
+    const writeState = nodeSupport[format].write.state;
+    const listState = nodeSupport[format].list.state;
+    return writeState === 'supported' && (listState === 'supported' || listState === 'hint-required');
+  }).slice(0, 4);
+
+  for (const format of candidateFormats) {
+    const tmpRoot = mkdtempSync(path.join(tmpdir(), `dir-archiver-matrix-${format.replace('/', '-')}-`));
+    try {
+      const source = path.join(tmpRoot, 'input.txt');
+      writeFileSync(source, `payload-${format}`);
+      const archive = path.join(tmpRoot, `bundle.${format.replace('/', '.')}`);
+
+      await write(source, archive, { format });
+      const openOptions = nodeSupport[format].detect.state === 'hint-required' ? { format } : {};
+      const detected = await detect(archive, openOptions);
+      assert.equal(isFormatEquivalent(detected.format, format), true);
+
+      const listed = await list(archive, openOptions);
+      assert.equal(listed.entries.length > 0, true);
+    } finally {
+      cleanup(tmpRoot);
+    }
+  }
+});
+
+const isFormatEquivalent = (actual, expected) => {
+  if (actual === expected) {
+    return true;
+  }
+  return (actual === 'tgz' && expected === 'tar.gz') || (actual === 'tar.gz' && expected === 'tgz');
+};
+
+test('node matrix unsupported write formats fail with stable code', async () => {
+  const nodeSupport = runtimeSupport('node');
+  const unsupportedFormat = supportMatrix.formats.find((format) => nodeSupport[format].write.state === 'unsupported');
+  assert.ok(unsupportedFormat, 'expected at least one unsupported write format');
+
+  const tmpRoot = mkdtempSync(path.join(tmpdir(), 'dir-archiver-matrix-unsupported-'));
+  try {
+    const source = path.join(tmpRoot, 'source');
+    mkdirSync(source, { recursive: true });
+    writeFileSync(path.join(source, 'input.txt'), 'payload');
+    const archive = path.join(tmpRoot, 'out.archive');
+
+    await assert.rejects(
+      async () => {
+        await write(source, archive, { format: unsupportedFormat });
+      },
+      (error) => error instanceof DirArchiverError && error.code === 'DIRARCHIVER_UNSUPPORTED_ENTRY'
+    );
+  } finally {
+    cleanup(tmpRoot);
+  }
+});

--- a/test/operations.test.mjs
+++ b/test/operations.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { audit, detect, extract, list, normalize, write } from '../dist/index.js';
+
+const removeDir = (dirPath) => {
+  rmSync(dirPath, { recursive: true, force: true });
+};
+
+test('write/detect/list/audit/extract/normalize flow on zip', async () => {
+  const tmpRoot = mkdtempSync(path.join(tmpdir(), 'dir-archiver-v3-'));
+  try {
+    const source = path.join(tmpRoot, 'source');
+    const nested = path.join(source, 'nested');
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(path.join(source, 'root.txt'), 'root');
+    writeFileSync(path.join(source, 'skip.txt'), 'skip');
+    writeFileSync(path.join(nested, 'nested.txt'), 'nested');
+
+    const archive = path.join(tmpRoot, 'bundle.zip');
+    const writeResult = await write(source, archive, {
+      format: 'zip',
+      includeBaseDirectory: true,
+      exclude: ['skip.txt']
+    });
+    assert.equal(writeResult.format, 'zip');
+    assert.equal(writeResult.entryCount, 2);
+    assert.equal(existsSync(archive), true);
+
+    const detectResult = await detect(archive, {});
+    assert.equal(detectResult.format, 'zip');
+
+    const listed = await list(archive, {});
+    assert.equal(listed.format, 'zip');
+    assert.equal(listed.entries.some((entry) => entry.name.endsWith('/skip.txt')), false);
+    assert.equal(listed.entries.some((entry) => entry.name.endsWith('/root.txt')), true);
+
+    const auditReport = await audit(archive, { profile: 'strict' });
+    assert.equal(auditReport.ok, true);
+
+    const extractTarget = path.join(tmpRoot, 'extracted');
+    const extractResult = await extract(archive, extractTarget, { profile: 'strict' });
+    assert.equal(extractResult.extractedFiles, 2);
+    const extractedRoot = path.join(extractTarget, path.basename(source), 'root.txt');
+    assert.equal(readFileSync(extractedRoot, 'utf8'), 'root');
+
+    const normalizedTarget = path.join(tmpRoot, 'normalized.zip');
+    const normalizeResult = await normalize(archive, normalizedTarget, { deterministic: true });
+    assert.equal(normalizeResult.format, 'zip');
+    assert.equal(existsSync(normalizedTarget), true);
+  } finally {
+    removeDir(tmpRoot);
+  }
+});
+
+test('directory + single-file codec wraps into tar.<codec>', async () => {
+  const tmpRoot = mkdtempSync(path.join(tmpdir(), 'dir-archiver-v3-'));
+  try {
+    const source = path.join(tmpRoot, 'source');
+    mkdirSync(source, { recursive: true });
+    writeFileSync(path.join(source, 'hello.txt'), 'hello');
+
+    const archive = path.join(tmpRoot, 'wrapped.gz');
+    const result = await write(source, archive, { format: 'gz' });
+    assert.equal(result.format, 'tar.gz');
+    assert.equal(result.wrappedDirectoryCodec, true);
+  } finally {
+    removeDir(tmpRoot);
+  }
+});

--- a/test/security.test.mjs
+++ b/test/security.test.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createWriteStream } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { Writable } from 'node:stream';
+import test from 'node:test';
+import { createArchiveWriter } from '@ismail-elkorchi/bytefold/node';
+import { extract } from '../dist/index.js';
+import { DirArchiverError } from '../dist/errors.js';
+
+const encoder = new TextEncoder();
+
+const cleanup = (target) => {
+  rmSync(target, { recursive: true, force: true });
+};
+
+const buildZip = async (targetPath, entries) => {
+  const writable = Writable.toWeb(createWriteStream(targetPath));
+  const writer = createArchiveWriter('zip', writable);
+  for (const entry of entries) {
+    await writer.add(entry.name, encoder.encode(entry.content));
+  }
+  await writer.close();
+};
+
+test('extract rejects traversal and absolute entry paths', async () => {
+  const tmpRoot = mkdtempSync(path.join(tmpdir(), 'dir-archiver-security-'));
+  try {
+    const archive = path.join(tmpRoot, 'traversal.zip');
+    await buildZip(archive, [
+      { name: '../escape.txt', content: 'x' }
+    ]);
+
+    await assert.rejects(
+      async () => extract(archive, path.join(tmpRoot, 'out'), { profile: 'strict' }),
+      (error) => error instanceof DirArchiverError && error.code === 'DIRARCHIVER_PATH_TRAVERSAL'
+    );
+
+    const absoluteArchive = path.join(tmpRoot, 'absolute.zip');
+    await buildZip(absoluteArchive, [
+      { name: '/abs.txt', content: 'x' }
+    ]);
+
+    await assert.rejects(
+      async () => extract(absoluteArchive, path.join(tmpRoot, 'out-abs'), { profile: 'strict' }),
+      (error) => error instanceof DirArchiverError && error.code === 'DIRARCHIVER_PATH_TRAVERSAL'
+    );
+  } finally {
+    cleanup(tmpRoot);
+  }
+});
+
+test('extract enforces decompression byte budgets', async () => {
+  const tmpRoot = mkdtempSync(path.join(tmpdir(), 'dir-archiver-security-'));
+  try {
+    const archive = path.join(tmpRoot, 'budget.zip');
+    await buildZip(archive, [
+      { name: 'big.txt', content: '12345678901234567890' }
+    ]);
+
+    await assert.rejects(
+      async () => extract(archive, path.join(tmpRoot, 'budget-out'), {
+        profile: 'strict',
+        maxEntryBytes: 8
+      }),
+      (error) => error instanceof DirArchiverError && error.code === 'DIRARCHIVER_RESOURCE_LIMIT'
+    );
+  } finally {
+    cleanup(tmpRoot);
+  }
+});
+
+test('extract rejects duplicate/conflicting names under strict profile', async () => {
+  const tmpRoot = mkdtempSync(path.join(tmpdir(), 'dir-archiver-security-'));
+  try {
+    const archive = path.join(tmpRoot, 'duplicate.zip');
+    await buildZip(archive, [
+      { name: 'dup.txt', content: 'one' },
+      { name: 'dup.txt', content: 'two' }
+    ]);
+
+    await assert.rejects(
+      async () => extract(archive, path.join(tmpRoot, 'dup-out'), { profile: 'agent' }),
+      (error) => error instanceof DirArchiverError && error.code === 'DIRARCHIVER_UNSUPPORTED_ENTRY'
+    );
+  } finally {
+    cleanup(tmpRoot);
+  }
+});

--- a/tools/docs-policy.json
+++ b/tools/docs-policy.json
@@ -1,0 +1,14 @@
+{
+  "entrypoints": [
+    "src/index.ts"
+  ],
+  "symbolFiles": [
+    "src/index.ts",
+    "src/core.ts",
+    "src/types.ts",
+    "src/errors.ts"
+  ],
+  "minDocumentedSymbols": 0.7,
+  "baselineMinDocumentedSymbols": 0.7,
+  "targetTotal": 14
+}

--- a/tools/runtime-versions.json
+++ b/tools/runtime-versions.json
@@ -1,0 +1,30 @@
+{
+  "node": {
+    "floor": "24.0.0",
+    "pinned": "24"
+  },
+  "deno": {
+    "floor": "2.6.7",
+    "pinned": "2.6.7"
+  },
+  "bun": {
+    "floor": "1.3.3",
+    "pinned": "1.3.3"
+  },
+  "policy": {
+    "staleness": {
+      "node": {
+        "maxMajorLag": 0,
+        "maxMinorLag": 1
+      },
+      "deno": {
+        "maxMajorLag": 0,
+        "maxMinorLag": 2
+      },
+      "bun": {
+        "maxMajorLag": 0,
+        "maxMinorLag": 2
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- rewrite `dir-archiver` as a bytefold-backed v3 orchestration layer (`open/detect/list/audit/extract/normalize/write`)
- add runtime adapters for Node/Deno/Bun and migrate format handling to bytefold APIs (remove legacy zip-only internals)
- introduce v3 contract docs, security fixtures, CLI schema tests, support-derived runtime matrix, determinism fingerprints, and downstream gates
- harden CI/release workflows (pinned actions, dependency-review, runtime policy, least privilege, non-blocking latest checks)
- align dependency source to released packages (`@ismail-elkorchi/bytefold@^0.7.2`, `argv-flags@^1.0.3`) and bump version metadata to `3.0.0`

## Oracles
- `npm run check` (pass)
- `npm run jsr:dry` (pass)
- `npm run test:downstream:released` (pass)
- `npm run test:downstream:main` (pass)
- `rg -n "\\barchiver\\b|zip-next" src` (no matches)
