### PR TITLE
Security gate: harden score and fingerprint scripts

### DIFF
--- a/scripts/jsr-score-gate.mjs
+++ b/scripts/jsr-score-gate.mjs
@@ -2,23 +2,13 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 const ROOT = process.cwd();
+const PACKAGE_SCOPE = 'ismail-elkorchi';
+const PACKAGE_NAME = 'dir-archiver';
+const SCORE_URL = `https://api.jsr.io/scopes/${PACKAGE_SCOPE}/packages/${PACKAGE_NAME}/score`;
 
 const run = async () => {
-  const jsr = JSON.parse(await readFile(path.join(ROOT, 'jsr.json'), 'utf8'));
   const policy = JSON.parse(await readFile(path.join(ROOT, 'tools', 'docs-policy.json'), 'utf8'));
-
-  const jsrName = String(jsr.name ?? '');
-  const match = jsrName.match(/^@([^/]+)\/([^/]+)$/);
-  if (!match) {
-    throw new Error(`Invalid jsr package name: ${jsrName}`);
-  }
-  const scope = match[1];
-  const pkg = match[2];
-  if (!scope || !pkg) {
-    throw new Error(`Invalid jsr package name: ${jsrName}`);
-  }
-
-  const response = await fetch(`https://api.jsr.io/scopes/${scope}/packages/${pkg}/score`);
+  const response = await fetch(SCORE_URL);
   if (!response.ok) {
     throw new Error(`JSR score API request failed: ${response.status}`);
   }

--- a/scripts/runtime-fingerprint.mjs
+++ b/scripts/runtime-fingerprint.mjs
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { extract, list, write } from '../dist/index.js';
@@ -65,12 +65,11 @@ function collectExtractedDescriptors(rootDir) {
   return descriptors;
 
   function visit(currentPath, relativePrefix) {
-    const entries = readdirSync(currentPath);
+    const entries = readdirSync(currentPath, { withFileTypes: true });
     for (const entry of entries) {
-      const absolutePath = path.join(currentPath, entry);
-      const relativePath = relativePrefix.length > 0 ? path.join(relativePrefix, entry) : entry;
-      const stats = statSync(absolutePath);
-      if (stats.isDirectory()) {
+      const absolutePath = path.join(currentPath, entry.name);
+      const relativePath = relativePrefix.length > 0 ? path.join(relativePrefix, entry.name) : entry.name;
+      if (entry.isDirectory()) {
         visit(absolutePath, relativePath);
         continue;
       }

--- a/tools/docs-policy.json
+++ b/tools/docs-policy.json
@@ -10,5 +10,5 @@
   ],
   "minDocumentedSymbols": 0.7,
   "baselineMinDocumentedSymbols": 0.7,
-  "targetTotal": 14
+  "targetTotal": 18
 }


### PR DESCRIPTION
## Summary
- hardcode JSR score API scope/package URL in `scripts/jsr-score-gate.mjs` to remove tainted URL construction
- remove TOCTOU `statSync` pattern in `scripts/runtime-fingerprint.mjs` by switching to directory entries with `withFileTypes`
- raise docs-policy score target from 14 to 18

## Validation
- `npm run check` (pass)

## Adversarial falsification
- `npm run test:runtimes` still produces identical runtime fingerprint hash after script hardening
