### PR TITLE
Release truth: enforce parity and generate GitHub releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+      - chore
+      - internal
+      - dependencies
+      - github_actions
+  categories:
+    - title: 🚀 Features
+      labels:
+        - feature
+        - enhancement
+    - title: 🐛 Fixes
+      labels:
+        - fix
+        - bug
+        - bugfix
+    - title: 🔒 Security
+      labels:
+        - security
+    - title: 🧰 Maintenance
+      labels:
+        - maintenance
+        - refactor
+        - docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,47 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  github_release:
+    name: Publish GitHub release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Load runtime policy
+        id: runtime-policy
+        shell: bash
+        run: |
+          node -e "const fs=require('node:fs');const p=JSON.parse(fs.readFileSync('tools/runtime-versions.json','utf8'));fs.appendFileSync(process.env.GITHUB_OUTPUT,'node_pinned='+p.node.pinned+'\\n');"
+      - name: Setup Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: ${{ steps.runtime-policy.outputs.node_pinned }}
+      - name: Release gate
+        run: node ./scripts/release-gate.mjs
+      - name: Extract changelog section
+        run: node ./scripts/changelog-section.mjs > release-notes.md
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if gh release view "${TAG_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "Release ${TAG_NAME} already exists; skipping create."
+          else
+            gh release create "${TAG_NAME}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${TAG_NAME#v}" \
+              --notes-file release-notes.md \
+              --generate-notes
+          fi
+
   npm:
     name: Publish npm
+    needs: [github_release]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -65,6 +104,8 @@ jobs:
 
   jsr:
     name: Publish JSR
+    needs: [github_release]
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:

--- a/scripts/changelog-section.mjs
+++ b/scripts/changelog-section.mjs
@@ -1,0 +1,74 @@
+import { readFile } from 'node:fs/promises';
+
+const run = async () => {
+  const tagInput = process.env.GITHUB_REF_NAME ?? process.argv[2] ?? '';
+  const tagName = normalizeTag(tagInput);
+  if (!tagName.startsWith('v')) {
+    throw new Error(`changelog-section: expected v-prefixed tag, received "${tagName}"`);
+  }
+  const version = tagName.slice(1);
+
+  const source = (await readFile('CHANGELOG.md', 'utf8')).replace(/\r\n/g, '\n');
+  const lines = source.split('\n');
+  const startMatch = findSectionStart(lines, version);
+  if (!startMatch) {
+    throw new Error(`changelog-section: could not find section for ${version}`);
+  }
+
+  const sectionLines = [];
+  for (let index = startMatch.index; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    if (index > startMatch.index && isHeadingAtLevel(line, startMatch.level)) {
+      break;
+    }
+    sectionLines.push(line);
+  }
+
+  const section = trimTrailingBlankLines(sectionLines).join('\n').trimEnd();
+  if (section.length === 0) {
+    throw new Error(`changelog-section: extracted section for ${version} is empty`);
+  }
+
+  process.stdout.write(`${section}\n`);
+};
+
+function normalizeTag(value) {
+  if (!value) return '';
+  if (value.startsWith('refs/tags/')) {
+    return value.slice('refs/tags/'.length);
+  }
+  return value;
+}
+
+function findSectionStart(lines, version) {
+  const matcher = new RegExp(`^\\s*(#{2,3})\\s+v?${escapeRegExp(version)}(?:\\b|\\s|\\(|-|$)`);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    const match = line.match(matcher);
+    if (!match) continue;
+    return { index, level: match[1].length };
+  }
+  return null;
+}
+
+function isHeadingAtLevel(line, level) {
+  const expected = '#'.repeat(level);
+  return new RegExp(`^\\s*${escapeRegExp(expected)}\\s+`).test(line);
+}
+
+function trimTrailingBlankLines(lines) {
+  let end = lines.length;
+  while (end > 0 && (lines[end - 1] ?? '').trim().length === 0) {
+    end -= 1;
+  }
+  return lines.slice(0, end);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+run().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -1,0 +1,49 @@
+import { readFile } from 'node:fs/promises';
+
+const run = async () => {
+  const tagInput = process.env.GITHUB_REF_NAME ?? process.argv[2] ?? '';
+  const tagName = normalizeTag(tagInput);
+  if (!tagName.startsWith('v')) {
+    throw new Error(`release-gate: expected v-prefixed tag, received "${tagName}"`);
+  }
+
+  const version = tagName.slice(1);
+  const packageJson = JSON.parse(await readFile('package.json', 'utf8'));
+  if (packageJson.version !== version) {
+    throw new Error(
+      `release-gate: tag/version mismatch (tag=${version}, package.json=${packageJson.version})`
+    );
+  }
+
+  const changelog = await readFile('CHANGELOG.md', 'utf8');
+  const sectionPattern = new RegExp(
+    `^#{2,3}\\s+v?${escapeRegExp(version)}(?:\\b|\\s|\\(|-|$)`,
+    'm'
+  );
+  if (!sectionPattern.test(changelog)) {
+    throw new Error(`release-gate: missing CHANGELOG section for version ${version}`);
+  }
+
+  process.stdout.write(
+    `release-gate: ok tag=${tagName} package=${packageJson.version} changelog=present\n`
+  );
+};
+
+function normalizeTag(value) {
+  if (!value) {
+    return '';
+  }
+  if (value.startsWith('refs/tags/')) {
+    return value.slice('refs/tags/'.length);
+  }
+  return value;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+run().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add `.github/release.yml` categories/exclusions for generated notes
- add `scripts/release-gate.mjs` to enforce tag/package/changelog parity
- add `scripts/changelog-section.mjs` to extract matching changelog section
- update release workflow to create GitHub Release before npm/JSR publish

## Verification
- `GITHUB_REF_NAME=v3.0.0 node ./scripts/release-gate.mjs`
- `GITHUB_REF_NAME=v3.0.0 node ./scripts/changelog-section.mjs`
- `npm run check`
