### PR TITLE
Refresh runtime dependencies and gate release on freshness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: ${{ steps.runtime-policy.outputs.node_pinned }}
+      - name: Runtime dependency freshness gate
+        run: npm run deps:fresh
       - name: Release gate
         run: node ./scripts/release-gate.mjs
       - name: Extract changelog section

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,12 @@ npm run check
 - Add/update tests for behavior changes.
 - Update `docs/V3_CONTRACT.md` for API or guarantee changes.
 
+## Runtime dependency freshness policy
+
+- Keep direct runtime dependencies in `package.json` and `package-lock.json` on the latest published stable versions before every release.
+- Validate with `npm run deps:fresh` (this gate runs in the release workflow).
+- If a dependency is stale, update it in a dedicated PR and run `npm run check`.
+
 ## Pull request checklist
 
 - [ ] `npm run check` passes locally

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@ismail-elkorchi/bytefold": "^0.7.2",
+        "@ismail-elkorchi/bytefold": "^0.8.0",
         "argv-flags": "^1.0.3"
       },
       "bin": {
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@ismail-elkorchi/bytefold": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@ismail-elkorchi/bytefold/-/bytefold-0.7.2.tgz",
-      "integrity": "sha512-knFkqPBGaBNIa90mxEL5sUYJb1QC/U5l6hgE+OueVwVcu62oaycqvhL+fnP0MWcSfCHxL0EMcYqNypyo5bfofg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@ismail-elkorchi/bytefold/-/bytefold-0.8.0.tgz",
+      "integrity": "sha512-EtfdkGSHbBV5zLwa2Dk6KgGwntlUiHzV2UbbuqDm6ytdW6/OAJm9jm/PBKue2fhTxbMj/D0CRj6x8XbgX7TFow==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -260,6 +260,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -454,6 +455,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -574,6 +576,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -1082,6 +1085,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1189,6 +1193,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1372,9 +1377,9 @@
       "dev": true
     },
     "@ismail-elkorchi/bytefold": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@ismail-elkorchi/bytefold/-/bytefold-0.7.2.tgz",
-      "integrity": "sha512-knFkqPBGaBNIa90mxEL5sUYJb1QC/U5l6hgE+OueVwVcu62oaycqvhL+fnP0MWcSfCHxL0EMcYqNypyo5bfofg=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@ismail-elkorchi/bytefold/-/bytefold-0.8.0.tgz",
+      "integrity": "sha512-EtfdkGSHbBV5zLwa2Dk6KgGwntlUiHzV2UbbuqDm6ytdW6/OAJm9jm/PBKue2fhTxbMj/D0CRj6x8XbgX7TFow=="
     },
     "@types/esrecurse": {
       "version": "4.3.1",
@@ -1424,6 +1429,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -1530,7 +1536,8 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -1610,6 +1617,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -1953,7 +1961,8 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -2018,7 +2027,8 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "undici-types": {
       "version": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "test": "npm run build && node --test test/api-snapshot.test.mjs test/operations.test.mjs test/cli.test.mjs test/matrix-node.test.mjs",
     "test:security": "npm run build && node --test test/security.test.mjs",
     "check": "node ./scripts/verify-runtime-versions.mjs && node ./scripts/workflow-policy-check.mjs && node ./scripts/esm-only-guard.mjs && node ./scripts/docs-policy-check.mjs && npm run lint && npm run test && npm run test:security && npm run test:runtimes",
+    "deps:fresh": "node ./scripts/direct-runtime-deps-freshness.mjs",
     "test:deno": "npm run build && deno run --allow-read --allow-write --allow-env --allow-sys test/deno-smoke.mjs",
     "test:bun": "npm run build && bun test/bun-smoke.mjs",
     "test:runtimes": "npm run test:deno && npm run test:bun && npm run test:runtimes:fingerprints",
@@ -65,7 +66,7 @@
     "node": ">=24"
   },
   "dependencies": {
-    "@ismail-elkorchi/bytefold": "^0.7.2",
+    "@ismail-elkorchi/bytefold": "^0.8.0",
     "argv-flags": "^1.0.3"
   },
   "devDependencies": {

--- a/scripts/direct-runtime-deps-freshness.mjs
+++ b/scripts/direct-runtime-deps-freshness.mjs
@@ -1,0 +1,101 @@
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const run = async () => {
+  const packageJson = JSON.parse(await readFile('package.json', 'utf8'));
+  const packageLock = JSON.parse(await readFile('package-lock.json', 'utf8'));
+  const runtimeDependencies = Object.entries(packageJson.dependencies ?? {});
+
+  if (runtimeDependencies.length === 0) {
+    process.stdout.write('[deps:fresh] no direct runtime dependencies declared\n');
+    return;
+  }
+
+  const violations = [];
+
+  for (const [name, declaredRange] of runtimeDependencies) {
+    const latest = await loadLatestVersion(name);
+    const locked = loadLockedVersion(packageLock, name);
+
+    if (!locked) {
+      violations.push({
+        name,
+        declaredRange,
+        latest,
+        reason: 'missing lockfile entry'
+      });
+      continue;
+    }
+
+    if (locked !== latest) {
+      violations.push({
+        name,
+        declaredRange,
+        locked,
+        latest,
+        reason: 'outdated lockfile/runtime dependency'
+      });
+    }
+  }
+
+  if (violations.length > 0) {
+    process.stderr.write('[deps:fresh] runtime dependency freshness check failed\n');
+    for (const violation of violations) {
+      const lockedPart = violation.locked ? ` locked=${violation.locked}` : '';
+      process.stderr.write(
+        `- ${violation.name}: range=${violation.declaredRange}${lockedPart} latest=${violation.latest} (${violation.reason})\n`
+      );
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(
+    `[deps:fresh] ok ${runtimeDependencies.map(([name]) => name).join(', ')}\n`
+  );
+};
+
+async function loadLatestVersion(packageName) {
+  const { stdout } = await execFileAsync(
+    'npm',
+    ['view', packageName, 'version', '--json'],
+    {
+      encoding: 'utf8'
+    }
+  );
+  const parsed = JSON.parse(stdout);
+  if (typeof parsed === 'string') {
+    return parsed;
+  }
+  if (Array.isArray(parsed)) {
+    const last = parsed.at(-1);
+    if (typeof last === 'string' && last.length > 0) {
+      return last;
+    }
+  }
+  throw new Error(`[deps:fresh] unable to parse latest version for ${packageName}`);
+}
+
+function loadLockedVersion(packageLock, packageName) {
+  const packageEntryVersion =
+    packageLock.packages?.[`node_modules/${packageName}`]?.version;
+  if (typeof packageEntryVersion === 'string' && packageEntryVersion.length > 0) {
+    return packageEntryVersion;
+  }
+  const dependencyEntryVersion = packageLock.dependencies?.[packageName]?.version;
+  if (
+    typeof dependencyEntryVersion === 'string' &&
+    dependencyEntryVersion.length > 0
+  ) {
+    return dependencyEntryVersion;
+  }
+  return null;
+}
+
+run().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- bump `@ismail-elkorchi/bytefold` from `^0.7.2` to `^0.8.0`
- add `scripts/direct-runtime-deps-freshness.mjs` and `npm run deps:fresh`
- run dependency freshness gate in `.github/workflows/release.yml` before GitHub release creation
- document direct runtime dependency freshness policy in `CONTRIBUTING.md`

## Evidence before PR
- `package.json` had `"@ismail-elkorchi/bytefold": "^0.7.2"`
- `npm outdated --json --depth=0` showed runtime drift:
  - `@ismail-elkorchi/bytefold current=0.7.2 latest=0.8.0`
- release workflow had no direct-runtime dependency freshness step before release creation

## Evidence after changes (local)
- `npm run deps:fresh`
  - `[deps:fresh] ok @ismail-elkorchi/bytefold, argv-flags`
- runtime-only outdated filter:
  - `{ "runtimeOutdated": {} }`
- `npm run check` passes (includes Node/Deno/Bun runtime tests)
