### PR TITLE
Add release-audit workflow for release parity and PR-note checks

### DIFF
--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -1,0 +1,32 @@
+name: Release audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  release_audit:
+    name: Release parity and notes audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Load runtime policy
+        id: runtime-policy
+        shell: bash
+        run: |
+          node -e "const fs=require('node:fs');const p=JSON.parse(fs.readFileSync('tools/runtime-versions.json','utf8'));fs.appendFileSync(process.env.GITHUB_OUTPUT,'node_pinned='+p.node.pinned+'\\n');"
+      - name: Setup Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: ${{ steps.runtime-policy.outputs.node_pinned }}
+      - name: Audit release state
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: npm run release:audit

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "test:runtimes": "npm run test:deno && npm run test:bun && npm run test:runtimes:fingerprints",
     "test:runtimes:fingerprints": "npm run build && node ./scripts/compare-runtime-fingerprints.mjs",
     "jsr:score": "node ./scripts/jsr-score-gate.mjs",
+    "release:audit": "node ./scripts/release-audit.mjs",
     "test:downstream:released": "npm run test",
     "test:downstream:main": "npm install --no-save github:Ismail-elkorchi/bytefold#main github:Ismail-elkorchi/argv-flags#main && npm run test",
     "jsr:dry": "deno publish --dry-run --allow-dirty --sloppy-imports",

--- a/scripts/release-audit.mjs
+++ b/scripts/release-audit.mjs
@@ -1,0 +1,119 @@
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const run = async () => {
+  const repository = await resolveRepository();
+  const latestRelease = await ghApiJson(`repos/${repository}/releases/latest`);
+  const latestTags = await ghApiJson(`repos/${repository}/tags?per_page=1`);
+  const latestTag = latestTags[0]?.name;
+
+  if (!latestTag) {
+    throw new Error('[release-audit] no tags found in repository');
+  }
+
+  if (latestRelease.tag_name !== latestTag) {
+    throw new Error(
+      `[release-audit] latest release/tag mismatch (release=${latestRelease.tag_name}, tag=${latestTag})`
+    );
+  }
+
+  const packageJson = JSON.parse(await readFile('package.json', 'utf8'));
+  const expectedTag = `v${packageJson.version}`;
+  if (latestTag !== expectedTag) {
+    throw new Error(
+      `[release-audit] package/tag mismatch (package=${packageJson.version}, tag=${latestTag})`
+    );
+  }
+
+  const changelog = await readFile('CHANGELOG.md', 'utf8');
+  if (!hasChangelogSection(changelog, packageJson.version)) {
+    throw new Error(
+      `[release-audit] CHANGELOG.md missing section for version ${packageJson.version}`
+    );
+  }
+
+  const releaseBody = String(latestRelease.body ?? '');
+  if (!containsPullRequestReference(releaseBody)) {
+    throw new Error(
+      `[release-audit] latest release body for ${latestTag} is missing pull request references`
+    );
+  }
+
+  process.stdout.write(
+    `[release-audit] ok repo=${repository} tag=${latestTag} version=${packageJson.version}\n`
+  );
+};
+
+async function ghApiJson(pathname) {
+  const args = ['api', pathname];
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  const environment = token
+    ? { ...process.env, GH_TOKEN: token }
+    : process.env;
+  const { stdout } = await execFileAsync('gh', args, { encoding: 'utf8', env: environment });
+  return JSON.parse(stdout);
+}
+
+async function resolveRepository() {
+  const explicit = process.env.GITHUB_REPOSITORY?.trim();
+  if (explicit) {
+    return explicit;
+  }
+
+  const { stdout } = await execFileAsync(
+    'git',
+    ['remote', 'get-url', 'origin'],
+    { encoding: 'utf8' }
+  );
+  const remote = stdout.trim();
+  return normalizeRepositoryFromRemote(remote);
+}
+
+function normalizeRepositoryFromRemote(remote) {
+  const noGitSuffix = remote.endsWith('.git') ? remote.slice(0, -4) : remote;
+  if (noGitSuffix.startsWith('git@github.com:')) {
+    return noGitSuffix.slice('git@github.com:'.length);
+  }
+  if (noGitSuffix.startsWith('https://github.com/')) {
+    return noGitSuffix.slice('https://github.com/'.length);
+  }
+  throw new Error(`[release-audit] unsupported origin remote format: ${remote}`);
+}
+
+function hasChangelogSection(changelog, version) {
+  const normalized = changelog.replace(/\r\n/g, '\n');
+  const lines = normalized.split('\n');
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!(line.startsWith('## ') || line.startsWith('### '))) {
+      continue;
+    }
+    const heading = line.replace(/^#{2,3}\s+/, '').trim();
+    const withoutV = heading.startsWith('v') ? heading.slice(1) : heading;
+    if (withoutV === version) {
+      return true;
+    }
+    if (withoutV.startsWith(`${version} `)) {
+      return true;
+    }
+    if (withoutV.startsWith(`${version} (`)) {
+      return true;
+    }
+    if (withoutV.startsWith(`${version}-`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function containsPullRequestReference(value) {
+  return /#[0-9]+/.test(value) || /\/pull\/[0-9]+/.test(value);
+}
+
+run().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add `scripts/release-audit.mjs` to verify:
  - latest GitHub release tag equals latest git tag
  - tag equals `v${package.json.version}`
  - `CHANGELOG.md` has the current release section
  - latest release body includes PR references (`#123` or `/pull/123`)
- add `npm run release:audit`
- add scheduled/manual `.github/workflows/release-audit.yml`

## Evidence before PR
- `.github/workflows/release-audit.yml` was missing
- no dedicated scheduled/manual guard existed for release/tag/changelog/release-note parity

## Evidence after changes (local)
- `GITHUB_TOKEN=$(gh auth token) npm run release:audit` passes
- `npm run check` passes
