### PR TITLE
Enforce strict release PR audits and remove repetitive author notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,15 @@ jobs:
         run: npm run deps:fresh
       - name: Release gate
         run: node ./scripts/release-gate.mjs
-      - name: Extract changelog section
-        run: node ./scripts/changelog-section.mjs > release-notes.md
+      - name: Build release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          node ./scripts/changelog-section.mjs > release-notes.md
+          printf '\n' >> release-notes.md
+          node ./scripts/release-audit.mjs --print-pr-section --tag "${TAG_NAME}" >> release-notes.md
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -50,8 +57,7 @@ jobs:
             gh release create "${TAG_NAME}" \
               --repo "${GITHUB_REPOSITORY}" \
               --title "${TAG_NAME#v}" \
-              --notes-file release-notes.md \
-              --generate-notes
+              --notes-file release-notes.md
           fi
 
   npm:


### PR DESCRIPTION
## Summary
- upgrade `scripts/release-audit.mjs` to strict mode:
  - derive expected PR set from tag range commit history
  - require release body PR refs to exactly match expected set
  - keep tag/package/changelog parity checks
- add `--print-pr-section --tag <vX.Y.Z>` mode to emit deterministic PR section
- update release workflow to build notes from changelog + deterministic PR section
- remove `gh release create --generate-notes` to stop repetitive `by @...` author lines

## Evidence
- `GITHUB_TOKEN=$(gh auth token) npm run release:audit` passes
- `node ./scripts/release-audit.mjs --print-pr-section --tag v3.0.0` outputs strict PR list
- `npm run check` passes
