### PR TITLE
chore(release): refresh runtime dependency freshness for v3.0.1

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -6,10 +6,10 @@
     ".": "./src/index.ts"
   },
   "imports": {
-    "@ismail-elkorchi/bytefold": "jsr:@ismail-elkorchi/bytefold@^0.8.0",
-    "@ismail-elkorchi/bytefold/node": "jsr:@ismail-elkorchi/bytefold/node@^0.8.0",
-    "@ismail-elkorchi/bytefold/deno": "jsr:@ismail-elkorchi/bytefold/deno@^0.8.0",
-    "@ismail-elkorchi/bytefold/bun": "jsr:@ismail-elkorchi/bytefold/bun@^0.8.0"
+    "@ismail-elkorchi/bytefold": "jsr:@ismail-elkorchi/bytefold@^0.8.1",
+    "@ismail-elkorchi/bytefold/node": "jsr:@ismail-elkorchi/bytefold/node@^0.8.1",
+    "@ismail-elkorchi/bytefold/deno": "jsr:@ismail-elkorchi/bytefold/deno@^0.8.1",
+    "@ismail-elkorchi/bytefold/bun": "jsr:@ismail-elkorchi/bytefold/bun@^0.8.1"
   },
   "publish": {
     "include": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ismail-elkorchi/bytefold": "^0.8.0",
-        "argv-flags": "^1.0.3"
+        "@ismail-elkorchi/bytefold": "^0.8.1",
+        "argv-flags": "^1.0.4"
       },
       "bin": {
         "dir-archiver": "dist/cli.js"
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@ismail-elkorchi/bytefold": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@ismail-elkorchi/bytefold/-/bytefold-0.8.0.tgz",
-      "integrity": "sha512-EtfdkGSHbBV5zLwa2Dk6KgGwntlUiHzV2UbbuqDm6ytdW6/OAJm9jm/PBKue2fhTxbMj/D0CRj6x8XbgX7TFow==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@ismail-elkorchi/bytefold/-/bytefold-0.8.1.tgz",
+      "integrity": "sha512-rCh/MJhgwXnrhWbY23lkVMrvsy7bmksKp/EDt2G2hrzc0lv1DpIdOZ8hX2klmdAUK4D0g0U4FMu4XtNolXWAaA==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -489,9 +489,9 @@
       }
     },
     "node_modules/argv-flags": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/argv-flags/-/argv-flags-1.0.3.tgz",
-      "integrity": "sha512-g7JENERmaoMTjxpl0OsUz6fx/97zYP3EzE5bUDgMKnvZ8ic6YnNreiG9IUEQFIZo6VFHJf8Tf/dfSoM0uliAPA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/argv-flags/-/argv-flags-1.0.4.tgz",
+      "integrity": "sha512-IewGGLqeGyYot4drKzxKUSX80YTuW38ED9xalYPC+1k6b3vUyocrS1dy3PT/4zgcW0144JoOnxHuzOyWlH/mUQ==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -1377,9 +1377,9 @@
       "dev": true
     },
     "@ismail-elkorchi/bytefold": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@ismail-elkorchi/bytefold/-/bytefold-0.8.0.tgz",
-      "integrity": "sha512-EtfdkGSHbBV5zLwa2Dk6KgGwntlUiHzV2UbbuqDm6ytdW6/OAJm9jm/PBKue2fhTxbMj/D0CRj6x8XbgX7TFow=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@ismail-elkorchi/bytefold/-/bytefold-0.8.1.tgz",
+      "integrity": "sha512-rCh/MJhgwXnrhWbY23lkVMrvsy7bmksKp/EDt2G2hrzc0lv1DpIdOZ8hX2klmdAUK4D0g0U4FMu4XtNolXWAaA=="
     },
     "@types/esrecurse": {
       "version": "4.3.1",
@@ -1559,9 +1559,9 @@
       }
     },
     "argv-flags": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/argv-flags/-/argv-flags-1.0.3.tgz",
-      "integrity": "sha512-g7JENERmaoMTjxpl0OsUz6fx/97zYP3EzE5bUDgMKnvZ8ic6YnNreiG9IUEQFIZo6VFHJf8Tf/dfSoM0uliAPA=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/argv-flags/-/argv-flags-1.0.4.tgz",
+      "integrity": "sha512-IewGGLqeGyYot4drKzxKUSX80YTuW38ED9xalYPC+1k6b3vUyocrS1dy3PT/4zgcW0144JoOnxHuzOyWlH/mUQ=="
     },
     "brace-expansion": {
       "version": "5.0.4",

--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
     "node": ">=24"
   },
   "dependencies": {
-    "@ismail-elkorchi/bytefold": "^0.8.0",
-    "argv-flags": "^1.0.3"
+    "@ismail-elkorchi/bytefold": "^0.8.1",
+    "argv-flags": "^1.0.4"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary
Refresh runtime dependency ranges/lockfile so release freshness gates pass for v3.0.1.

## Changes
- Update `@ismail-elkorchi/bytefold` runtime range to `^0.8.1`.
- Update `argv-flags` runtime range to `^1.0.4`.
- Regenerate `package-lock.json`.

## Verification
```bash
npm run deps:fresh
npm run check:fast
```

## Risk
Low; no runtime behavior changes.
