### PR TITLE
Fix JSR docs type surface

### DIFF
--- a/scripts/jsr-docs-quality.mjs
+++ b/scripts/jsr-docs-quality.mjs
@@ -2,6 +2,7 @@ import { execFile } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
+import { pathToFileURL } from 'node:url';
 
 const execFileAsync = promisify(execFile);
 const ROOT = process.cwd();
@@ -23,7 +24,7 @@ const run = async () => {
   );
 
   const documentTree = JSON.parse(stdout);
-  const docsByPath = collectDocs(Array.isArray(documentTree?.nodes) ? documentTree.nodes : []);
+  const docsByPath = collectDocs(documentTree, sourceFile);
   const failures = [];
 
   for (const symbolPath of requiredDocs) {
@@ -45,9 +46,10 @@ const run = async () => {
   }
 };
 
-function collectDocs(nodes) {
+function collectDocs(nodes, sourceFile) {
   const docsByPath = new Map();
-  for (const node of nodes) {
+  const normalizedNodes = normalizeNodes(nodes, sourceFile);
+  for (const node of normalizedNodes) {
     const rootName = node?.isDefault === true ? 'default' : String(node?.name ?? '');
     if (rootName.length === 0) {
       continue;
@@ -58,6 +60,20 @@ function collectDocs(nodes) {
 }
 
 function collectNodeDocs(pathPrefix, node, docsByPath) {
+  const declarations = Array.isArray(node?.declarations) ? node.declarations : [];
+
+  if (declarations.length === 1) {
+    collectDeclarationDocs(pathPrefix, declarations[0], docsByPath);
+    return;
+  }
+
+  if (declarations.length > 1) {
+    for (let index = 0; index < declarations.length; index += 1) {
+      collectDeclarationDocs(`${pathPrefix}#${index}`, declarations[index], docsByPath);
+    }
+    return;
+  }
+
   docsByPath.set(pathPrefix, normalizeDoc(node?.jsDoc));
 
   if (node?.kind === 'class') {
@@ -69,6 +85,32 @@ function collectNodeDocs(pathPrefix, node, docsByPath) {
   if (node?.kind === 'interface') {
     collectMembers(pathPrefix, node.interfaceDef?.properties, docsByPath);
     collectMembers(pathPrefix, node.interfaceDef?.methods, docsByPath);
+  }
+
+  if (node?.kind === 'enum') {
+    collectMembers(pathPrefix, node.enumDef?.members, docsByPath);
+  }
+}
+
+function collectDeclarationDocs(pathPrefix, declaration, docsByPath) {
+  if (!declaration || typeof declaration !== 'object') {
+    return;
+  }
+
+  docsByPath.set(pathPrefix, normalizeDoc(declaration.jsDoc));
+  const def = declaration.def;
+  if (!def || typeof def !== 'object') {
+    return;
+  }
+
+  collectMembers(pathPrefix, def.properties, docsByPath);
+  collectMembers(pathPrefix, def.methods, docsByPath);
+  collectMembers(pathPrefix, def.interfaceDef?.properties, docsByPath);
+  collectMembers(pathPrefix, def.interfaceDef?.methods, docsByPath);
+  collectMembers(pathPrefix, def.classDef?.properties, docsByPath);
+  collectMembers(pathPrefix, def.classDef?.methods, docsByPath);
+  if (declaration.kind === 'enum' || def.kind === 'enum') {
+    collectMembers(pathPrefix, def.members, docsByPath);
   }
 }
 
@@ -83,6 +125,44 @@ function collectMembers(pathPrefix, members, docsByPath) {
     }
     docsByPath.set(`${pathPrefix}.${name}`, normalizeDoc(member?.jsDoc));
   }
+}
+
+function normalizeNodes(documentTree, sourceFile = 'src/index.ts') {
+  if (!documentTree) {
+    return [];
+  }
+  if (Array.isArray(documentTree)) {
+    return documentTree;
+  }
+  if (documentTree.nodes && typeof documentTree.nodes === 'object' && !Array.isArray(documentTree.nodes)) {
+    const sourceUrl = getSourceFileUrl(documentTree.nodes, sourceFile);
+    if (sourceUrl !== '') {
+      const moduleNode = documentTree.nodes[sourceUrl];
+      if (moduleNode) {
+        return moduleNode.symbols ?? [];
+      }
+    }
+
+    const fallback = Object.values(documentTree.nodes).find((value) => Array.isArray(value?.symbols));
+    if (fallback && Array.isArray(fallback.symbols)) {
+      return fallback.symbols;
+    }
+  }
+  return [];
+}
+
+function getSourceFileUrl(nodesMap, sourceFile) {
+  const candidate = path.resolve(process.cwd(), sourceFile);
+  const preferred = pathToFileURL(candidate).href;
+  if (nodesMap[preferred]) {
+    return preferred;
+  }
+  const fallback = path.resolve(process.cwd(), String(sourceFile));
+  const fallbackUrl = pathToFileURL(fallback).href;
+  if (nodesMap[fallbackUrl]) {
+    return fallbackUrl;
+  }
+  return '';
 }
 
 function normalizeDoc(jsDoc) {

--- a/scripts/jsr-docs-quality.mjs
+++ b/scripts/jsr-docs-quality.mjs
@@ -134,6 +134,9 @@ function normalizeNodes(documentTree, sourceFile = 'src/index.ts') {
   if (Array.isArray(documentTree)) {
     return documentTree;
   }
+  if (Array.isArray(documentTree.nodes)) {
+    return documentTree.nodes;
+  }
   if (documentTree.nodes && typeof documentTree.nodes === 'object' && !Array.isArray(documentTree.nodes)) {
     const sourceUrl = getSourceFileUrl(documentTree.nodes, sourceFile);
     if (sourceUrl !== '') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,9 @@ export type { DirArchiverErrorCode, DirArchiverErrorJson } from './errors.js';
 export type {
   ArchiveFormat,
   ArchiveLimits,
+  ArchiveDetectionReport,
+  ArchiveIssue,
+  ArchiveNormalizeReport,
   ArchiveProfile,
   CliUsageError,
   DetectResult,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,24 @@
 import type {
-  ArchiveDetectionReport,
   ArchiveFormat,
-  ArchiveIssue,
-  ArchiveLimits,
-  ArchiveNormalizeReport,
-  ArchiveOpenOptions,
   ArchiveProfile
 } from '@ismail-elkorchi/bytefold';
 
-export type { ArchiveFormat, ArchiveLimits, ArchiveProfile };
+export type {
+  ArchiveFormat,
+  ArchiveProfile,
+} from '@ismail-elkorchi/bytefold';
+
+/** Resource limit configuration accepted by `open`, `audit`, and extraction flows. */
+export type ArchiveLimits = Record<string, unknown>;
+
+/** Issue shape emitted for archive read/normalize/extract failures. */
+export type ArchiveIssue = Record<string, unknown>;
+
+/** Public detection report shape aligned with runtime diagnostics payloads. */
+export type ArchiveDetectionReport = Record<string, unknown>;
+
+/** Public normalize report shape for deterministic archive rewrites. */
+export type ArchiveNormalizeReport = Record<string, unknown>;
 
 /**
  * Accepted input shapes for archive read operations.
@@ -34,31 +44,31 @@ export interface OpenOptions
   /**
    * Explicit format override when callers already know archive type.
    */
-  format?: ArchiveOpenOptions['format'] | undefined;
+  format?: ArchiveFormat | 'auto' | undefined;
   /**
    * Safety profile (`compat`, `strict`, `agent`) applied during reads/audits.
    */
-  profile?: ArchiveOpenOptions['profile'] | undefined;
+  profile?: ArchiveProfile | undefined;
   /**
    * Extra strictness toggle forwarded to bytefold parsing.
    */
-  isStrict?: ArchiveOpenOptions['isStrict'] | undefined;
+  isStrict?: boolean | undefined;
   /**
    * Parser/resource limits enforced while opening or auditing archives.
    */
-  limits?: ArchiveOpenOptions['limits'] | undefined;
+  limits?: ArchiveLimits | undefined;
   /**
    * Abort signal for cancelling in-flight async operations.
    */
-  signal?: ArchiveOpenOptions['signal'] | undefined;
+  signal?: AbortSignal | undefined;
   /**
    * Password used for encrypted archives when supported by the runtime.
    */
-  password?: ArchiveOpenOptions['password'] | undefined;
+  password?: string | undefined;
   /**
    * Filename hint used for extension-based inference with non-path inputs.
    */
-  filename?: ArchiveOpenOptions['filename'] | undefined;
+  filename?: string | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary
- avoid private bytefold type references in the public JSR documentation surface
- support the current Deno doc JSON structure in the docs-quality checker
- include enum members when collecting declaration docs

## Validation
- npm run docs:quality:jsr
- npm run typecheck