### PR TITLE
Update argv-flags to 1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ismail-elkorchi/bytefold": "^0.8.1",
-        "argv-flags": "^1.0.4"
+        "argv-flags": "^1.0.5"
       },
       "bin": {
         "dir-archiver": "dist/cli.js"
@@ -508,9 +508,9 @@
       }
     },
     "node_modules/argv-flags": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/argv-flags/-/argv-flags-1.0.4.tgz",
-      "integrity": "sha512-IewGGLqeGyYot4drKzxKUSX80YTuW38ED9xalYPC+1k6b3vUyocrS1dy3PT/4zgcW0144JoOnxHuzOyWlH/mUQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/argv-flags/-/argv-flags-1.0.5.tgz",
+      "integrity": "sha512-uu0E5q1V8AMxyBofqfhoQMHYo5jZX2ZOuA992aKetOO5Qo9FBtfPZmoumlywx8kM907wgQVj1Gjc+NH6JgeTBw==",
       "license": "MIT",
       "engines": {
         "node": ">=24"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@ismail-elkorchi/bytefold": "^0.8.1",
-    "argv-flags": "^1.0.4"
+    "argv-flags": "^1.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary
- update argv-flags from 1.0.4 to 1.0.5
- refresh the lockfile entry for the direct runtime dependency

## Validation
- npm run deps:fresh
- npm test