### PR TITLE
Prepare release 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 * No entries yet.
 
+### 3.0.2 (June 19, 2026)
+
+* Fix JSR documentation checks for current and pinned Deno doc output.
+* Update `argv-flags` to 1.0.5.
+* Bump GitHub Actions dependencies in CI and release workflows.
+
 ### 3.0.1 (March 3, 2026)
 
 * Rework README/docs information architecture for fast first-use onboarding.

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@ismail-elkorchi/dir-archiver",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dir-archiver",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dir-archiver",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@ismail-elkorchi/bytefold": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dir-archiver",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Deterministic directory archiving and extraction over zip, tar, and layered compression.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump npm and JSR package metadata to 3.0.2
- add the 3.0.2 changelog entry without Node compatibility wording
- include the merged JSR docs fix, argv-flags update, and GitHub Actions refresh in the release notes

## Validation
- npm run check
- npm run jsr:dry
- npm publish --dry-run