### PR TITLE
Remove legacy documentation pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 * Rebuild the consumer documentation around seven canonical pages for onboarding, API, CLI, safety, formats, and troubleshooting.
 * Correct Deno installation, CLI audit-gate, output-stream, runtime-format, alias, symlink, extraction, write, normalize, and error-handling guidance against the implementation and tests.
 * Replace Unix-only onboarding commands with a self-contained cross-platform example for Node.js, Deno, and Bun consumers.
-* Remove duplicated recipe and maintainer documentation; retain older consumer URLs only as repository-level moved-page notices.
+* Remove duplicated recipe, maintainer, and compatibility-page documentation so `docs/` contains only the canonical consumer guides.
 * Publish only the canonical consumer guides in npm and JSR packages.
 * Align exported option and error JSDoc with current v3 behavior.
-* Add automated checks for local Markdown links, heading anchors, publication boundaries, canonical page ownership, compatibility notices, and CLI documentation drift.
+* Add automated checks for local Markdown links, heading anchors, publication boundaries, canonical page ownership, and CLI documentation drift.
 * Keep archive runtime behavior and CLI semantics unchanged.
 
 ### 3.0.2 (June 19, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 ### 3.0.1 (March 3, 2026)
 
 * Rework README/docs information architecture for fast first-use onboarding.
-* Expand `docs/reference/cli.md` as the canonical CLI command/flag/output reference.
+* Expand the CLI documentation as the canonical command/flag/output reference.
 * Add runnable offline examples and wire `npm run examples:run` into check flows.
 * Add example doc blocks (Goal/Prereqs/Run/Expected output/Safety notes) for each example file.
 * Keep archive runtime behavior and CLI semantics unchanged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,20 +49,7 @@ Each subject has one canonical consumer page:
 | Stability boundary | `CONTRACT.md` |
 | Vulnerability reporting | `SECURITY.md` |
 
-Do not add a second tutorial, recipe, how-to, explanation, or reference page when the content belongs in a canonical page. Add a section to the owning page and link directly to that section.
-
-## Compatibility notices
-
-Paths used by earlier releases under `docs/tutorial/`, `docs/how-to/`, `docs/reference/`, and `docs/explanation/` remain in the source repository only as small moved-page notices.
-
-Each notice must:
-
-- contain exactly one link to its canonical replacement;
-- contain no copied examples, option tables, or reference material;
-- remain excluded from new npm and JSR packages;
-- stay covered by `test/docs-links.test.mjs`.
-
-Do not add new content to a compatibility path.
+The `docs/` directory contains only the seven canonical consumer pages listed above. Do not add a second tutorial, recipe, how-to, explanation, redirect, or reference page when the content belongs in an existing page. Add a section to the owning page and link directly to that section.
 
 ## Documentation quality rules
 
@@ -92,8 +79,8 @@ Consumer CLI examples should use the installed executable, normally `npx dir-arc
 - local Markdown targets and heading anchors;
 - that links do not escape the repository;
 - that npm and JSR Markdown links resolve within each published package;
-- that all consumer content stays on the canonical pages;
-- that older paths remain minimal moved-page notices.
+- that all seven canonical consumer pages exist and are published;
+- that no additional Markdown pages are added under `docs/`.
 
 A green link test does not validate behavioral claims. Review documentation changes against:
 
@@ -122,6 +109,6 @@ Generated API documentation and Markdown must agree. In particular:
 - [ ] behavior changes have tests
 - [ ] consumer docs match the implementation and current dependency matrix
 - [ ] npm and JSR package-local links pass the documentation test
-- [ ] compatibility notices still point to the canonical destinations
+- [ ] `docs/` contains only the seven canonical consumer pages
 - [ ] `CONTRACT.md` is updated for stability-boundary changes
 - [ ] `CHANGELOG.md` includes release-relevant changes

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,5 +1,0 @@
-# Page moved
-
-This compatibility page is retained for links from earlier releases.
-
-Read the [documentation map](../index.md).

--- a/docs/explanation/profiles.md
+++ b/docs/explanation/profiles.md
@@ -1,5 +1,0 @@
-# Page moved
-
-This compatibility page is retained for links from earlier releases.
-
-Read [Safety: profiles](../safety.md#profiles).

--- a/docs/how-to/cli-json-and-exit-codes.md
+++ b/docs/how-to/cli-json-and-exit-codes.md
@@ -1,5 +1,0 @@
-# Page moved
-
-This compatibility page is retained for links from earlier releases.
-
-Read [CLI: automation contract](../cli.md#automation-contract).

--- a/docs/how-to/extract-untrusted.md
+++ b/docs/how-to/extract-untrusted.md
@@ -1,5 +1,0 @@
-# Page moved
-
-This compatibility page is retained for links from earlier releases.
-
-Read [Safety: recommended extraction flow](../safety.md#recommended-extraction-flow).

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,5 +1,0 @@
-# Page moved
-
-This compatibility page is retained for links from earlier releases.
-
-Read the [documentation map](../index.md).

--- a/docs/how-to/troubleshoot-common-failures.md
+++ b/docs/how-to/troubleshoot-common-failures.md
@@ -1,5 +1,0 @@
-# Page moved
-
-This compatibility page is retained for links from earlier releases.
-
-Read [Troubleshooting](../troubleshooting.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,5 +35,3 @@ Start with the task you need to complete. Each subject has one canonical page so
 - [Security policy](../SECURITY.md)
 - [Support](../SUPPORT.md)
 - [Changelog](../CHANGELOG.md)
-
-Older documentation paths remain in the source repository as small moved-page notices so existing GitHub links continue to work. They are not included in new npm or JSR packages, and new documentation belongs only on the canonical pages above.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,5 +1,0 @@
-# Page moved
-
-This compatibility page is retained for links from earlier releases.
-
-Read the [CLI guide](../cli.md).

--- a/docs/reference/contract.md
+++ b/docs/reference/contract.md
@@ -1,5 +1,0 @@
-# Page moved
-
-This compatibility page is retained for links from earlier releases.
-
-Read the [public behavior contract](../../CONTRACT.md).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,5 +1,0 @@
-# Page moved
-
-This compatibility page is retained for links from earlier releases.
-
-Read the [documentation map](../index.md).

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -1,5 +1,0 @@
-# Page moved
-
-This compatibility page is retained for links from earlier releases.
-
-Read the [API guide](../api.md).

--- a/docs/tutorial/bundle-a-plugin.md
+++ b/docs/tutorial/bundle-a-plugin.md
@@ -1,5 +1,0 @@
-# Page moved
-
-This compatibility page is retained for links from earlier releases.
-
-Read [API: write](../api.md#write).

--- a/docs/tutorial/first-archive-flow.md
+++ b/docs/tutorial/first-archive-flow.md
@@ -1,5 +1,0 @@
-# Page moved
-
-This compatibility page is retained for links from earlier releases.
-
-Read [Getting started](../getting-started.md).

--- a/test/docs-links.test.mjs
+++ b/test/docs-links.test.mjs
@@ -29,21 +29,6 @@ const canonicalConsumerDocs = new Set([
   'docs/troubleshooting.md'
 ]);
 
-const legacyMovedPages = new Map([
-  ['docs/tutorial/first-archive-flow.md', '../getting-started.md'],
-  ['docs/tutorial/bundle-a-plugin.md', '../api.md#write'],
-  ['docs/how-to/index.md', '../index.md'],
-  ['docs/how-to/cli-json-and-exit-codes.md', '../cli.md#automation-contract'],
-  ['docs/how-to/extract-untrusted.md', '../safety.md#recommended-extraction-flow'],
-  ['docs/how-to/troubleshoot-common-failures.md', '../troubleshooting.md'],
-  ['docs/reference/index.md', '../index.md'],
-  ['docs/reference/cli.md', '../cli.md'],
-  ['docs/reference/options.md', '../api.md'],
-  ['docs/reference/contract.md', '../../CONTRACT.md'],
-  ['docs/explanation/index.md', '../index.md'],
-  ['docs/explanation/profiles.md', '../safety.md#profiles']
-]);
-
 const packageManifest = JSON.parse(
   fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')
 );
@@ -94,7 +79,7 @@ const normalizeMarkdownTarget = (raw) => {
 
 const isExternalTarget = (target) => /^(?:https?:|mailto:|tel:|data:|javascript:)/iu.test(target);
 
-const collectLinks = (source, includeExternal = false) => {
+const collectLinks = (source) => {
   const links = [];
   const lines = source.replace(/\r\n/gu, '\n').split('\n');
   let fence = undefined;
@@ -119,7 +104,7 @@ const collectLinks = (source, includeExternal = false) => {
     for (const match of line.matchAll(expression)) {
       const raw = (match[1] ?? '').trim();
       const target = normalizeMarkdownTarget(raw);
-      if (!target || (!includeExternal && isExternalTarget(target))) {
+      if (!target || isExternalTarget(target)) {
         continue;
       }
       links.push({ target, line: index + 1 });
@@ -296,56 +281,23 @@ for (const [label, entries] of publicationEntries) {
   });
 }
 
-test('canonical consumer pages are present and published', () => {
+test('docs directory contains only canonical consumer pages', () => {
+  const docsMarkdown = walk(path.join(repoRoot, 'docs'))
+    .filter((filePath) => path.extname(filePath).toLowerCase() === '.md')
+    .map(relative)
+    .sort();
+  const expected = [...canonicalConsumerDocs].sort();
+
+  assert.deepEqual(docsMarkdown, expected);
+});
+
+test('canonical consumer pages are published', () => {
   for (const requiredPath of canonicalConsumerDocs) {
-    assert.equal(fs.existsSync(path.join(repoRoot, requiredPath)), true, `missing ${requiredPath}`);
     for (const [label, entries] of publicationEntries) {
       assert.equal(
         manifestIncludesPath(requiredPath, entries),
         true,
         `${requiredPath} must be included in the ${label} package`
-      );
-    }
-  }
-});
-
-test('consumer documentation stays on canonical pages', () => {
-  const docsMarkdown = walk(path.join(repoRoot, 'docs'))
-    .filter((filePath) => path.extname(filePath).toLowerCase() === '.md')
-    .map(relative)
-    .sort();
-  const allowedDocs = new Set([
-    ...canonicalConsumerDocs,
-    ...legacyMovedPages.keys()
-  ]);
-  const unexpected = docsMarkdown.filter((relativePath) => !allowedDocs.has(relativePath));
-
-  assert.deepEqual(
-    unexpected,
-    [],
-    'consumer material must stay on canonical pages; old paths may only be move notices'
-  );
-});
-
-test('legacy documentation paths remain repository-only move notices', () => {
-  for (const [relativePath, target] of legacyMovedPages) {
-    const filePath = path.join(repoRoot, relativePath);
-    assert.equal(fs.existsSync(filePath), true, `missing ${relativePath}`);
-
-    const source = fs.readFileSync(filePath, 'utf8');
-    const links = collectLinks(source, true);
-
-    assert.match(source, /compatibility page is retained/iu, `${relativePath} needs a move notice`);
-    assert.equal(links.length, 1, `${relativePath} must contain exactly one link`);
-    assert.equal(links[0]?.target, target, `${relativePath} must point to ${target}`);
-    assert.equal(source.includes('```'), false, `${relativePath} must not duplicate examples`);
-    assert.ok(source.length < 500, `${relativePath} must stay minimal`);
-
-    for (const [label, entries] of publicationEntries) {
-      assert.equal(
-        manifestIncludesPath(relativePath, entries),
-        false,
-        `${relativePath} must stay out of the ${label} package`
       );
     }
   }


### PR DESCRIPTION
## Summary

- Remove the legacy moved-page files under `docs/tutorial`, `docs/how-to`, `docs/reference`, and `docs/explanation`.
- Remove documentation, contributor-policy, changelog, and test references that preserved the compatibility layer.
- Make `docs/` contain exactly the seven canonical consumer pages.
- Keep npm and JSR publication-boundary checks and local link/anchor checks intact.

## Why

The compatibility pages added another documentation layer without helping package consumers complete a task. Keeping them also required dedicated policy and test code, which made the repository preserve the fragmentation the canonical documentation structure was intended to remove.

## Validation

- CI: passed on Linux, the Node.js floor, macOS, and Windows
- CodeQL: passed
- Dependency Review: passed
- Downstream Compatibility: passed
- No unresolved review threads